### PR TITLE
I've updated the `cloud_services.html` file to display topics in a gr…

### DIFF
--- a/cloud_services.html
+++ b/cloud_services.html
@@ -20,83 +20,107 @@
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
     <main>
-      <h1 class="text-3xl font-bold mb-4">Cloud Services</h1>
+      <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+        <ol class="list-none p-0 inline-flex">
+          <li class="flex items-center">
+            <a href="index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+            <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+          </li>
+          <li class="flex items-center">
+            <span class="text-gray-700">Cloud Services</span>
+          </li>
+        </ol>
+      </nav>
+      <h1 class="text-3xl font-bold mb-6">Cloud Services</h1>
+      <p class="text-lg mb-6">Explore the various topics related to Cloud Services:</p>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
 
-      <h2 class="text-2xl font-bold mb-4">Protect your work information</h2>
-      <ul class="list-disc pl-5 space-y-2 mb-4">
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Microsoft Intune</h3>
-          <p class="mb-4">Information about Microsoft Intune will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Microsoft Entra Private Access</h3>
-          <p class="mb-4">Information about Microsoft Entra Private Access will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Microsoft Entra Internet Access</h3>
-          <p class="mb-4">Information about Microsoft Entra Internet Access will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Azure Information Protection</h3>
-          <p class="mb-4">Information about Azure Information Protection will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Microsoft Defender for Endpoint</h3>
-          <p class="mb-4"><strong>Microsoft Defender for Endpoint</strong> (formerly known as Windows Defender Advanced Threat Protection or WDATP) is a comprehensive, enterprise-grade security platform. It goes beyond traditional antivirus by providing advanced capabilities such as endpoint detection and response (EDR). EDR allows security teams to detect, investigate, and respond to advanced threats and attacks that might bypass other defenses. It also includes features like vulnerability management, which helps identify and remediate software vulnerabilities, and attack surface reduction. While it's a powerful tool primarily for businesses, understanding its existence highlights the sophisticated security capabilities available for Windows environments.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Cloud-native device management</h3>
-          <p class="mb-4">Information about Cloud-native device management will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Local Administrator Password Solution (LAPS)</h3>
-          <p class="mb-4">Information about Local Administrator Password Solution (LAPS) will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Windows Autopilot</h3>
-          <p class="mb-4">Information about Windows Autopilot will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Microsoft 365 Business</h3>
-          <p class="mb-4">Information about Microsoft 365 Business will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Microsoft Viva Goals</h3>
-          <p class="mb-4">Information about Microsoft Viva Goals will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Windows Notepads</h3>
-          <p class="mb-4">Information about Windows Notepads will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">OneDrive for work or school</h3>
-          <p class="mb-4">Information about OneDrive for work or school will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Universal Print</h3>
-          <p class="mb-4">Information about Universal Print will be available here.</p>
-        </li>
-      </ul>
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Microsoft Intune</h2>
+          <a href="posts/cloud_services_microsoft_intune.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
 
-      <h2 class="text-2xl font-bold mb-4">Protect your personal information</h2>
-      <ul class="list-disc pl-5 space-y-2 mb-4">
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Microsoft account</h3>
-          <p class="mb-4">Information about Microsoft account will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Find my device</h3>
-          <p class="mb-4">Information about Find my device will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Microsoft Vault</h3>
-          <p class="mb-4">Information about Microsoft Vault will be available here.</p>
-        </li>
-        <li class="mb-2">
-          <h3 class="text-xl font-bold mb-3">Personal S.M.A.R.T.</h3>
-          <p class="mb-4">Information about Personal S.M.A.R.T. will be available here.</p>
-        </li>
-      </ul>
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Microsoft Entra Private Access</h2>
+          <a href="posts/cloud_services_microsoft_entra_private_access.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Microsoft Entra Internet Access</h2>
+          <a href="posts/cloud_services_microsoft_entra_internet_access.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Azure Information Protection</h2>
+          <a href="posts/cloud_services_azure_information_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Microsoft Defender for Endpoint</h2>
+          <a href="posts/cloud_services_microsoft_defender_for_endpoint.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Cloud-native device management</h2>
+          <a href="posts/cloud_services_cloud_native_device_management.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Local Administrator Password Solution (LAPS)</h2>
+          <a href="posts/cloud_services_local_administrator_password_solution_laps.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Windows Autopilot</h2>
+          <a href="posts/cloud_services_windows_autopilot.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Microsoft 365 Business</h2>
+          <a href="posts/cloud_services_microsoft_365_business.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Microsoft Viva Goals</h2>
+          <a href="posts/cloud_services_microsoft_viva_goals.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Windows Notepads</h2>
+          <a href="posts/cloud_services_windows_notepads.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">OneDrive for work or school</h2>
+          <a href="posts/cloud_services_onedrive_for_work_or_school.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Universal Print</h2>
+          <a href="posts/cloud_services_universal_print.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Microsoft account</h2>
+          <a href="posts/cloud_services_microsoft_account.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Find my device</h2>
+          <a href="posts/cloud_services_find_my_device.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Microsoft Vault</h2>
+          <a href="posts/cloud_services_microsoft_vault.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
+          <h2 class="text-xl font-semibold mb-2">Personal S.M.A.R.T.</h2>
+          <a href="posts/cloud_services_personal_s_m_a_r_t.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        </div>
+
+      </div>
     </main>
   </div>
 </body>


### PR DESCRIPTION
…id layout. Now, each topic links to its individual post page within the `posts/` directory, bringing its structure in line with `operating_system.html`.

Here's a summary of the changes:

- I modified `cloud_services.html` to use a two-column grid for topic cards.
- Each card now contains the topic title and a 'Read more...' link to its respective post file.
- I added breadcrumb navigation (`Home > Cloud Services`) to `cloud_services.html`.
- I also verified that the individual post pages under `posts/cloud_services_*.html` already had the correct breadcrumb navigation, linking back to the updated `cloud_services.html` page.