### PR TITLE
Add breadcrumbs to posts in Operating System and Security Foundation …

### DIFF
--- a/posts/operating_system_5g_and_esim.html
+++ b/posts/operating_system_5g_and_esim.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">5G and eSIM</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">5G and eSIM</h1>
       <p class="mb-4">Information about 5G and eSIM will be available here.</p>

--- a/posts/operating_system_bitlocker.html
+++ b/posts/operating_system_bitlocker.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">BitLocker</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">BitLocker</h1>
       <p class="mb-4"><strong>BitLocker Drive Encryption</strong> is a full-disk encryption feature included with certain versions of Windows. Its primary purpose is to protect your data by encrypting the entire operating system drive (and optionally other fixed data drives). If a device protected by BitLocker is lost or stolen, the data on the drive remains encrypted and inaccessible without the correct decryption key, recovery password, or startup key. This is especially crucial for protecting sensitive information on laptops and other portable devices.</p>

--- a/posts/operating_system_bitlocker_to_go.html
+++ b/posts/operating_system_bitlocker_to_go.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">BitLocker To Go</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">BitLocker To Go</h1>
       <p class="mb-4">Information about BitLocker To Go will be available here.</p>

--- a/posts/operating_system_certificates.html
+++ b/posts/operating_system_certificates.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Certificates</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Certificates</h1>
       <p class="mb-4">Information about Certificates will be available here.</p>

--- a/posts/operating_system_code_signing_and_integrity.html
+++ b/posts/operating_system_code_signing_and_integrity.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Code signing and integrity</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Code signing and integrity</h1>
       <p class="mb-4">Information about Code signing and integrity will be available here.</p>

--- a/posts/operating_system_config_refresh.html
+++ b/posts/operating_system_config_refresh.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Config Refresh</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Config Refresh</h1>
       <p class="mb-4">Information about Config Refresh will be available here.</p>

--- a/posts/operating_system_controlled_folder_access.html
+++ b/posts/operating_system_controlled_folder_access.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Controlled folder access</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Controlled folder access</h1>
       <p class="mb-4">Information about Controlled folder access will be available here.</p>

--- a/posts/operating_system_cryptography.html
+++ b/posts/operating_system_cryptography.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Cryptography</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Cryptography</h1>
       <p class="mb-4">Information about Cryptography will be available here.</p>

--- a/posts/operating_system_device_health_attestation.html
+++ b/posts/operating_system_device_health_attestation.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Device health attestation</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Device health attestation</h1>
       <p class="mb-4">Information about Device health attestation will be available here.</p>

--- a/posts/operating_system_domain_name_system_dns_security.html
+++ b/posts/operating_system_domain_name_system_dns_security.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Domain Name System (DNS) security</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Domain Name System (DNS) security</h1>
       <p class="mb-4">Information about Domain Name System (DNS) security will be available here.</p>

--- a/posts/operating_system_email_encryption.html
+++ b/posts/operating_system_email_encryption.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Email encryption</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Email encryption</h1>
       <p class="mb-4">Information about Email encryption will be available here.</p>

--- a/posts/operating_system_encrypted_file_system_efs.html
+++ b/posts/operating_system_encrypted_file_system_efs.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Encrypted File System (EFS)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Encrypted File System (EFS)</h1>
       <p class="mb-4">Information about Encrypted File System (EFS) will be available here.</p>

--- a/posts/operating_system_encrypted_hard_drive.html
+++ b/posts/operating_system_encrypted_hard_drive.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Encrypted hard drive</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Encrypted hard drive</h1>
       <p class="mb-4">Information about Encrypted hard drive will be available here.</p>

--- a/posts/operating_system_exploit_protection.html
+++ b/posts/operating_system_exploit_protection.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Exploit protection</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Exploit protection</h1>
       <p class="mb-4">Information about Exploit protection will be available here.</p>

--- a/posts/operating_system_internet_protocol_security_ipsec.html
+++ b/posts/operating_system_internet_protocol_security_ipsec.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Internet Protocol Security (IPSec)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Internet Protocol Security (IPSec)</h1>
       <p class="mb-4">Information about Internet Protocol Security (IPSec) will be available here.</p>

--- a/posts/operating_system_kiosk_mode.html
+++ b/posts/operating_system_kiosk_mode.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Kiosk mode</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Kiosk mode</h1>
       <p class="mb-4">Information about Kiosk mode will be available here.</p>

--- a/posts/operating_system_microsoft_defender_antivirus.html
+++ b/posts/operating_system_microsoft_defender_antivirus.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Microsoft Defender Antivirus</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Microsoft Defender Antivirus</h1>
       <p class="mb-4">Microsoft Defender Antivirus provides real-time protection against malware, viruses, ransomware, and other threats. It is a key component of Windows Security and includes features for running scans to detect and remove malicious software. This is part of the broader <strong>Virus & threat protection</strong> managed within the Windows Security app.</p>

--- a/posts/operating_system_microsoft_defender_application_guard.html
+++ b/posts/operating_system_microsoft_defender_application_guard.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Microsoft Defender Application Guard</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Microsoft Defender Application Guard</h1>
       <p class="mb-4">Information about Microsoft Defender Application Guard will be available here. Note: This is also featured under Application Security for its role in application isolation.</p>

--- a/posts/operating_system_microsoft_defender_for_business.html
+++ b/posts/operating_system_microsoft_defender_for_business.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Microsoft Defender for Business</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Microsoft Defender for Business</h1>
       <p class="mb-4">Information about Microsoft Defender for Business will be available here.</p>

--- a/posts/operating_system_network_access_protection.html
+++ b/posts/operating_system_network_access_protection.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Network access protection</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Network access protection</h1>
       <p class="mb-4">Information about Network access protection will be available here.</p>

--- a/posts/operating_system_personal_data_encryption.html
+++ b/posts/operating_system_personal_data_encryption.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Personal data encryption</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Personal data encryption</h1>
       <p class="mb-4">Information about Personal data encryption will be available here.</p>

--- a/posts/operating_system_rust_for_windows.html
+++ b/posts/operating_system_rust_for_windows.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Rust for Windows</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Rust for Windows</h1>
       <p class="mb-4">Information about Rust for Windows will be available here.</p>

--- a/posts/operating_system_server_message_block_smb_for_remote_connections.html
+++ b/posts/operating_system_server_message_block_smb_for_remote_connections.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Server Message Block (SMB) for remote connections</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Server Message Block (SMB) for remote connections</h1>
       <p class="mb-4">Information about Server Message Block (SMB) for remote connections will be available here.</p>

--- a/posts/operating_system_tamper_protection.html
+++ b/posts/operating_system_tamper_protection.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Tamper protection</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Tamper protection</h1>
       <p class="mb-4">Information about Tamper protection will be available here.</p>

--- a/posts/operating_system_transport_layer_security_tls.html
+++ b/posts/operating_system_transport_layer_security_tls.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Transport Layer Security (TLS)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Transport Layer Security (TLS)</h1>
       <p class="mb-4">Information about Transport Layer Security (TLS) will be available here.</p>

--- a/posts/operating_system_wi_fi_protection.html
+++ b/posts/operating_system_wi_fi_protection.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Wi-Fi protection</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Wi-Fi protection</h1>
       <p class="mb-4">Information about Wi-Fi protection will be available here.</p>

--- a/posts/operating_system_windows_firewall.html
+++ b/posts/operating_system_windows_firewall.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Windows Firewall</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Windows Firewall</h1>
       <p class="mb-4">The <strong>Windows Defender Firewall</strong> (often just called Windows Firewall) is a built-in stateful firewall that helps protect your system from network-based threats by filtering incoming and outgoing network traffic. It acts as a barrier between your computer and the internet or other networks. You can configure firewall rules to allow or block specific types of traffic based on program, port, or IP address. These rules can be defined for different network profiles: Domain Profile (when connected to a corporate domain), Private Profile (for trusted private networks), and Public Profile (for untrusted public networks, typically with the most restrictive settings). Properly configuring inbound and outbound rules is crucial for maintaining a strong network defense. The Windows Security app provides a dashboard to manage Firewall & network protection.</p>

--- a/posts/operating_system_windows_protected_process.html
+++ b/posts/operating_system_windows_protected_process.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Windows protected process</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Windows protected process</h1>
       <p class="mb-4">Information about Windows protected process will be available here.</p>

--- a/posts/operating_system_windows_security_app.html
+++ b/posts/operating_system_windows_security_app.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Windows Security</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Windows Security</h1>
       <p class="mb-4">Windows comes with a built-in comprehensive security application called <strong>Windows Security</strong> (formerly known as Windows Defender Security Center). It provides a centralized dashboard to manage various security features including virus & threat protection, firewall & network protection, app & browser control, and device security. Regularly checking the Windows Security app ensures your device's protection status is green and all features are functioning correctly.</p>

--- a/posts/operating_system_windows_security_policy_settings_and_auditing.html
+++ b/posts/operating_system_windows_security_policy_settings_and_auditing.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../operating_system.html" class="text-gray-500 hover:text-gray-700">Operating System Security</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Windows security policy settings and auditing</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Windows security policy settings and auditing</h1>
       <p class="mb-4">Information about Windows security policy settings and auditing will be available here.</p>

--- a/posts/security_foundation_common_criteria_cc.html
+++ b/posts/security_foundation_common_criteria_cc.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../security_foundation.html" class="text-gray-500 hover:text-gray-700">Security Foundation</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Common Criteria (CC)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Common Criteria (CC)</h1>
       <p class="mb-4">Information about Common Criteria (CC) will be available here.</p>

--- a/posts/security_foundation_devdivsecops.html
+++ b/posts/security_foundation_devdivsecops.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../security_foundation.html" class="text-gray-500 hover:text-gray-700">Security Foundation</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">DevDivSecOps</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">DevDivSecOps</h1>
       <p class="mb-4">Information about DevDivSecOps will be available here.</p>

--- a/posts/security_foundation_federal_information_processing_standard_fips.html
+++ b/posts/security_foundation_federal_information_processing_standard_fips.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../security_foundation.html" class="text-gray-500 hover:text-gray-700">Security Foundation</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Federal Information Processing Standard (FIPS)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Federal Information Processing Standard (FIPS)</h1>
       <p class="mb-4">Information about Federal Information Processing Standard (FIPS) will be available here.</p>

--- a/posts/security_foundation_microsoft_offensive_research_and_security_engineering_morse.html
+++ b/posts/security_foundation_microsoft_offensive_research_and_security_engineering_morse.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../security_foundation.html" class="text-gray-500 hover:text-gray-700">Security Foundation</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Microsoft Offensive Research and Security Engineering (MORSE)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Microsoft Offensive Research and Security Engineering (MORSE)</h1>
       <p class="mb-4">Information about Microsoft Offensive Research and Security Engineering (MORSE) will be available here.</p>

--- a/posts/security_foundation_secure_future_initiative_sfi.html
+++ b/posts/security_foundation_secure_future_initiative_sfi.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../security_foundation.html" class="text-gray-500 hover:text-gray-700">Security Foundation</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Secure Future Initiative (SFI)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Secure Future Initiative (SFI)</h1>
       <p class="mb-4">Information about Secure Future Initiative (SFI) will be available here.</p>

--- a/posts/security_foundation_security_development_lifecycle_sdl.html
+++ b/posts/security_foundation_security_development_lifecycle_sdl.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../security_foundation.html" class="text-gray-500 hover:text-gray-700">Security Foundation</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Security Development Lifecycle (SDL)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Security Development Lifecycle (SDL)</h1>
       <p class="mb-4">Information about Security Development Lifecycle (SDL) will be available here.</p>

--- a/posts/security_foundation_software_bill_of_materials_sbom.html
+++ b/posts/security_foundation_software_bill_of_materials_sbom.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../security_foundation.html" class="text-gray-500 hover:text-gray-700">Security Foundation</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Software Bill of Materials (SBOM)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Software Bill of Materials (SBOM)</h1>
       <p class="mb-4">Information about Software Bill of Materials (SBOM) will be available here.</p>

--- a/posts/security_foundation_windows_kernel_and_microsoft_bug_bounty_programs.html
+++ b/posts/security_foundation_windows_kernel_and_microsoft_bug_bounty_programs.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../security_foundation.html" class="text-gray-500 hover:text-gray-700">Security Foundation</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Windows Kernel and Microsoft Bug Bounty Programs</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Windows Kernel and Microsoft Bug Bounty Programs</h1>
       <p class="mb-4">Information about Windows Kernel and Microsoft Bug Bounty Programs will be available here.</p>

--- a/posts/security_foundation_windows_software_development_kit_sdk.html
+++ b/posts/security_foundation_windows_software_development_kit_sdk.html
@@ -19,6 +19,21 @@
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
+    <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
+      <ol class="list-none p-0 inline-flex">
+        <li class="flex items-center">
+          <a href="../index.html" class="text-gray-500 hover:text-gray-700">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <a href="../security_foundation.html" class="text-gray-500 hover:text-gray-700">Security Foundation</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+        </li>
+        <li class="flex items-center">
+          <span class="text-gray-700">Windows Software Development Kit (SDK)</span>
+        </li>
+      </ol>
+    </nav>
     <main>
       <h1 class="text-3xl font-bold mb-4">Windows Software Development Kit (SDK)</h1>
       <p class="mb-4">Information about Windows Software Development Kit (SDK) will be available here.</p>


### PR DESCRIPTION
…categories

This change adds breadcrumb navigation to 39 posts across two categories:
- 30 posts in the "Operating System" category
- 9 posts in the "Security Foundation" category

The breadcrumbs improve site navigation by providing you with a clear path from the homepage to the category page and then to the specific post you are viewing.

The breadcrumb structure is: Home > Category Name > Post Title. The HTML for the breadcrumbs has been inserted consistently across all modified post files.