### PR TITLE
feat: Add interactive vulnerability timeline page

### DIFF
--- a/application.html
+++ b/application.html
@@ -16,6 +16,7 @@
       <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
       <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
       <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="timeline.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Timeline</a>
       <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>

--- a/cloud_services.html
+++ b/cloud_services.html
@@ -16,6 +16,7 @@
       <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
       <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
       <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="timeline.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Timeline</a>
       <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>

--- a/hardware.html
+++ b/hardware.html
@@ -16,6 +16,7 @@
       <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
       <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
       <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="timeline.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Timeline</a>
       <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>

--- a/identity.html
+++ b/identity.html
@@ -16,6 +16,7 @@
       <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
       <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
       <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="timeline.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Timeline</a>
       <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         <li><a href="operating_system.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Operating System</a></li>
         <li><a href="hardware.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Hardware</a></li>
         <li><a href="security_foundation.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Security Foundation</a></li>
+        <li><a href="timeline.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Timeline</a></li>
         <li><a href="resources.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Resources</a></li>
       </ul>
     </div>

--- a/operating_system.html
+++ b/operating_system.html
@@ -16,6 +16,7 @@
       <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
       <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
       <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="timeline.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Timeline</a>
       <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>

--- a/resources.html
+++ b/resources.html
@@ -16,6 +16,7 @@
     <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
     <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
     <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="timeline.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Timeline</a>
     <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
   </div>
 </nav>

--- a/security_foundation.html
+++ b/security_foundation.html
@@ -16,6 +16,7 @@
       <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
       <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
       <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="timeline.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Timeline</a>
       <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,34 @@
+/* Add any global styles or overrides here if needed */
+
+/* Styling for the timeline year header */
+.year-header {
+    transition: color 0.3s ease;
+}
+
+/* Styling for the vulnerability title */
+.vulnerability-title {
+    transition: color 0.3s ease;
+}
+
+/* Ensure the summary is not displayed by default via CSS as a fallback, JS will toggle it */
+.vulnerability-summary.hidden {
+    display: none;
+}
+
+/* Add a little more spacing for readability if multiple summaries are open */
+.vulnerability-summary:not(.hidden) + .vulnerability-summary:not(.hidden) {
+    margin-top: 0.5rem;
+}
+
+/* Basic responsive adjustments */
+@media (max-width: 768px) {
+    #timeline-container h1 {
+        font-size: 2rem; /* Adjust title size for smaller screens */
+    }
+    .year-header {
+        font-size: 1.5rem; /* Adjust year header size */
+    }
+    .vulnerability-title {
+        font-size: 1rem; /* Adjust vulnerability title size */
+    }
+}

--- a/timeline.html
+++ b/timeline.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vulnerability Timeline - Windows Security</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="style.css"> </head>
+<body class="bg-white dark:bg-gray-900">
+
+<nav class="bg-white border-gray-200 dark:bg-gray-900">
+  <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
+    <a href="index.html" class="flex items-center space-x-3 rtl:space-x-reverse">
+        <span class="self-center text-2xl font-semibold whitespace-nowrap dark:text-white">Windows Security</span>
+    </a>
+    <button data-collapse-toggle="navbar-default" type="button" class="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600" aria-controls="navbar-default" aria-expanded="false">
+        <span class="sr-only">Open main menu</span>
+        <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 17 14">
+            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h15M1 7h15M1 13h15"/>
+        </svg>
+    </button>
+    <div class="hidden w-full md:block md:w-auto" id="navbar-default">
+      <ul class="font-medium flex flex-col p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:flex-row md:space-x-8 rtl:space-x-reverse md:mt-0 md:border-0 md:bg-white dark:bg-gray-800 md:dark:bg-gray-900 dark:border-gray-700">
+        <li>
+          <a href="index.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">
+            Home
+          </a>
+        </li>
+        <li><a href="cloud_services.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Cloud Services</a></li>
+        <li><a href="identity.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Identity</a></li>
+        <li><a href="application.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Application</a></li>
+        <li><a href="operating_system.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Operating System</a></li>
+        <li><a href="hardware.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Hardware</a></li>
+        <li><a href="security_foundation.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Security Foundation</a></li>
+        <li><a href="timeline.html" class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0 dark:text-white md:dark:text-blue-500" aria-current="page">Timeline</a></li>
+        <li><a href="resources.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Resources</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mx-auto max-w-4xl p-6">
+  <main>
+    <h1 class="mb-4 text-4xl font-extrabold tracking-tight leading-none text-gray-900 md:text-5xl lg:text-6xl dark:text-white">Vulnerability Timeline</h1>
+    <p class="mb-6 text-lg font-normal text-gray-500 lg:text-xl dark:text-gray-400">An interactive timeline of discovered vulnerabilities. Click on a vulnerability to see its summary, or click on a year to see all vulnerabilities disclosed in that year.</p>
+    <div id="timeline-container" class="mt-10">
+      <!-- Timeline will be generated here by JavaScript -->
+    </div>
+  </main>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
+<script src="timeline.js"></script>
+</body>
+</html>

--- a/timeline.js
+++ b/timeline.js
@@ -1,0 +1,121 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const timelineContainer = document.getElementById('timeline-container');
+    let vulnerabilities = [];
+    let selectedYear = null;
+
+    async function fetchData() {
+        try {
+            const response = await fetch('vulnerabilities.json');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            vulnerabilities = await response.json();
+            renderTimeline();
+        } catch (error) {
+            console.error("Could not fetch vulnerabilities data:", error);
+            timelineContainer.innerHTML = '<p class="text-red-500">Failed to load vulnerability data. Please try again later.</p>';
+        }
+    }
+
+    function renderTimeline() {
+        timelineContainer.innerHTML = ''; // Clear previous content
+
+        if (vulnerabilities.length === 0) {
+            timelineContainer.innerHTML = '<p>No vulnerabilities to display.</p>';
+            return;
+        }
+
+        // Group vulnerabilities by year
+        const groupedByYear = vulnerabilities.reduce((acc, vuln) => {
+            (acc[vuln.year] = acc[vuln.year] || []).push(vuln);
+            return acc;
+        }, {});
+
+        // Sort years in descending order
+        const sortedYears = Object.keys(groupedByYear).sort((a, b) => b - a);
+
+        sortedYears.forEach(year => {
+            // Filter by selected year if any
+            if (selectedYear && parseInt(year) !== selectedYear) {
+                return;
+            }
+
+            const yearSection = document.createElement('div');
+            yearSection.className = 'mb-8';
+
+            const yearHeader = document.createElement('h2');
+            yearHeader.className = 'text-2xl font-bold text-gray-800 dark:text-white mb-4 cursor-pointer hover:text-blue-600 dark:hover:text-blue-400 year-header';
+            yearHeader.textContent = year;
+            yearHeader.dataset.year = year;
+            yearHeader.addEventListener('click', () => {
+                if (selectedYear && selectedYear === parseInt(year)) {
+                    selectedYear = null; // Deselect if clicking the same year
+                } else {
+                    selectedYear = parseInt(year);
+                }
+                renderTimeline(); // Re-render the timeline with the new year filter
+            });
+            yearSection.appendChild(yearHeader);
+
+            const yearVulnerabilities = groupedByYear[year];
+            const vulnerabilitiesList = document.createElement('ol');
+            vulnerabilitiesList.className = 'relative border-l border-gray-200 dark:border-gray-700 ml-4';
+
+            yearVulnerabilities.forEach(vuln => {
+                const listItem = document.createElement('li');
+                listItem.className = 'mb-10 ms-6';
+
+                const timePoint = document.createElement('span');
+                timePoint.className = 'absolute flex items-center justify-center w-6 h-6 bg-blue-100 rounded-full -start-3 ring-8 ring-white dark:ring-gray-900 dark:bg-blue-900';
+                const timePointIcon = document.createElement('svg');
+                timePointIcon.className = 'w-2.5 h-2.5 text-blue-800 dark:text-blue-300';
+                timePointIcon.setAttribute('aria-hidden', 'true');
+                timePointIcon.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+                timePointIcon.setAttribute('fill', 'currentColor');
+                timePointIcon.setAttribute('viewBox', '0 0 20 20');
+                timePointIcon.innerHTML = '<path d="M20 4a2 2 0 0 0-2-2h-2V1a1 1 0 0 0-2 0v1h-3V1a1 1 0 0 0-2 0v1H6V1a1 1 0 0 0-2 0v1H2a2 2 0 0 0-2 2v2h20V4Z"/><path d="M0 18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8H0v10Zm5-8h10a1 1 0 0 1 0 2H5a1 1 0 0 1 0-2Z"/>';
+                timePoint.appendChild(timePointIcon);
+
+                const title = document.createElement('h3');
+                title.className = 'flex items-center mb-1 text-lg font-semibold text-gray-900 dark:text-white cursor-pointer hover:text-blue-700 dark:hover:text-blue-500 vulnerability-title';
+                title.textContent = vuln.title;
+
+                const summaryDiv = document.createElement('div');
+                summaryDiv.className = 'hidden p-4 mt-2 mb-2 text-sm text-gray-700 bg-gray-100 rounded-lg dark:bg-gray-700 dark:text-gray-300 vulnerability-summary';
+                summaryDiv.textContent = vuln.summary;
+
+                title.addEventListener('click', () => {
+                    summaryDiv.classList.toggle('hidden');
+                });
+
+                const learnMoreLink = document.createElement('a');
+                learnMoreLink.href = vuln.details_url;
+                learnMoreLink.target = '_blank';
+                learnMoreLink.rel = 'noopener noreferrer';
+                learnMoreLink.className = 'inline-flex items-center px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:outline-none focus:ring-gray-100 focus:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 dark:focus:ring-gray-700';
+                learnMoreLink.innerHTML = 'Learn more <svg class="w-3 h-3 ms-2 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5h12m0 0L9 1m4 4L9 9"/></svg>';
+
+                listItem.appendChild(timePoint);
+                listItem.appendChild(title);
+                listItem.appendChild(summaryDiv); // Add summary div (initially hidden)
+                listItem.appendChild(learnMoreLink);
+                vulnerabilitiesList.appendChild(listItem);
+            });
+            yearSection.appendChild(vulnerabilitiesList);
+            timelineContainer.appendChild(yearSection);
+        });
+         // Add a "Show All" button if a year is selected
+        if (selectedYear) {
+            const showAllButton = document.createElement('button');
+            showAllButton.textContent = 'Show All Years';
+            showAllButton.className = 'mt-4 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:bg-blue-500 dark:hover:bg-blue-600 dark:focus:ring-blue-800';
+            showAllButton.addEventListener('click', () => {
+                selectedYear = null;
+                renderTimeline();
+            });
+            timelineContainer.insertBefore(showAllButton, timelineContainer.firstChild);
+        }
+    }
+
+    fetchData();
+});

--- a/vulnerabilities.json
+++ b/vulnerabilities.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "CVE-2023-12345",
+    "year": 2023,
+    "title": "Remote Code Execution Vulnerability",
+    "summary": "A critical vulnerability allowing remote code execution via a crafted request.",
+    "details_url": "https://example.com/cve-2023-12345"
+  },
+  {
+    "id": "CVE-2023-67890",
+    "year": 2023,
+    "title": "Privilege Escalation Flaw",
+    "summary": "An attacker can escalate privileges to administrator level due to improper input validation.",
+    "details_url": "https://example.com/cve-2023-67890"
+  },
+  {
+    "id": "CVE-2022-24680",
+    "year": 2022,
+    "title": "Cross-Site Scripting (XSS)",
+    "summary": "A persistent XSS vulnerability allows attackers to inject malicious scripts into web pages.",
+    "details_url": "https://example.com/cve-2022-24680"
+  },
+  {
+    "id": "CVE-2022-13579",
+    "year": 2022,
+    "title": "Denial of Service",
+    "summary": "A vulnerability that can lead to denial of service when processing large files.",
+    "details_url": "https://example.com/cve-2022-13579"
+  },
+  {
+    "id": "CVE-2021-54321",
+    "year": 2021,
+    "title": "SQL Injection Vulnerability",
+    "summary": "Sensitive data exposure due to an SQL injection vulnerability in the user login form.",
+    "details_url": "https://example.com/cve-2021-54321"
+  }
+]


### PR DESCRIPTION
This commit introduces a new page, `timeline.html`, which displays a timeline of vulnerabilities.

Key features:
- Vulnerabilities are loaded from `vulnerabilities.json`.
- Vulnerabilities are grouped by year and displayed in descending chronological order.
- You can click on a vulnerability title to view its summary.
- Each vulnerability has a "Learn more" link that opens in a new tab.
- You can click on a year to filter the timeline and show only vulnerabilities from that year.
- A "Show All Years" button allows you to clear the year filter.
- The page is styled using Tailwind CSS and Flowbite, with some additional custom CSS in `style.css`.
- Basic responsive design ensures usability on different screen sizes.
- Links to the new timeline page have been added to the navigation bar on all existing pages.