### PR TITLE
Apply consistent dark theme across all pages

### DIFF
--- a/application.html
+++ b/application.html
@@ -5,85 +5,85 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 text-gray-900">
+<body class="bg-gray-900 text-gray-300">
   <nav class="bg-gray-800 p-4">
     <div class="container mx-auto flex flex-wrap justify-center">
-      <a href="index.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">
+      <a href="index.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-home inline-block w-5 h-5 mr-1 align-text-bottom"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>Home</a>
-      <a href="cloud_services.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
-      <a href="identity.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
-      <a href="application.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
-      <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
-      <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
-      <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
-      <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
+      <a href="cloud_services.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
+      <a href="identity.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
+      <a href="application.html" class="text-white bg-blue-600 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
+      <a href="operating_system.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
+      <a href="hardware.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
+      <a href="security_foundation.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="resources.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
     <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
       <ol class="list-none p-0 inline-flex">
         <li class="flex items-center">
-          <a href="index.html" class="text-gray-500 hover:text-gray-700">Home</a>
-          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+          <a href="index.html" class="text-gray-400 hover:text-gray-200">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
         </li>
         <li class="flex items-center">
-          <span class="text-gray-700">Application Security</span>
+          <span class="text-white">Application Security</span>
         </li>
       </ol>
     </nav>
     <main>
-      <h1 class="text-3xl font-bold mb-6">Application Security</h1>
-      <p class="text-lg mb-6">Explore the various topics related to Application Security:</p>
+      <h1 class="text-3xl font-bold mb-6 text-white">Application Security</h1>
+      <p class="text-lg mb-6 text-gray-300">Explore the various topics related to Application Security:</p>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Applocker</h2>
-          <a href="posts/application_applocker.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Applocker</h2>
+          <a href="posts/application_applocker.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Browser Protection</h2>
-          <a href="posts/application_browser_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Browser Protection</h2>
+          <a href="posts/application_browser_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Microsoft Defender Application Guard</h2>
-          <a href="posts/application_microsoft_defender_application_guard.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Microsoft Defender Application Guard</h2>
+          <a href="posts/application_microsoft_defender_application_guard.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Microsoft Vulnerable Driver Block</h2>
-          <a href="posts/application_microsoft_vulnerable_driver_block.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Microsoft Vulnerable Driver Block</h2>
+          <a href="posts/application_microsoft_vulnerable_driver_block.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Smart App Control</h2>
-          <a href="posts/application_smart_app_control.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Smart App Control</h2>
+          <a href="posts/application_smart_app_control.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Trusted Signing</h2>
-          <a href="posts/application_trusted_signing.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Trusted Signing</h2>
+          <a href="posts/application_trusted_signing.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Virtualization Based Integrity (VBI)</h2>
-          <a href="posts/application_virtualization_based_integrity_vbi.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Virtualization Based Integrity (VBI)</h2>
+          <a href="posts/application_virtualization_based_integrity_vbi.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Sandbox</h2>
-          <a href="posts/application_windows_sandbox.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Sandbox</h2>
+          <a href="posts/application_windows_sandbox.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Subsystem For Linux (WSL)</h2>
-          <a href="posts/application_windows_subsystem_for_linux_wsl.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Subsystem For Linux (WSL)</h2>
+          <a href="posts/application_windows_subsystem_for_linux_wsl.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">WSL App Isolation</h2>
-          <a href="posts/application_wsl_app_isolation.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">WSL App Isolation</h2>
+          <a href="posts/application_wsl_app_isolation.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
       </div>

--- a/cloud_services.html
+++ b/cloud_services.html
@@ -5,18 +5,18 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 text-gray-900">
+<body class="bg-gray-900 text-gray-300">
   <nav class="bg-gray-800 p-4">
     <div class="container mx-auto flex flex-wrap justify-center">
-      <a href="index.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">
+      <a href="index.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-home inline-block w-5 h-5 mr-1 align-text-bottom"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>Home</a>
-      <a href="cloud_services.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
-      <a href="identity.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
-      <a href="application.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
-      <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
-      <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
-      <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
-      <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
+      <a href="cloud_services.html" class="text-white bg-blue-600 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
+      <a href="identity.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
+      <a href="application.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
+      <a href="operating_system.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
+      <a href="hardware.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
+      <a href="security_foundation.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="resources.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
@@ -24,126 +24,126 @@
       <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
         <ol class="list-none p-0 inline-flex">
           <li class="flex items-center">
-            <a href="index.html" class="text-gray-500 hover:text-gray-700">Home</a>
-            <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+            <a href="index.html" class="text-gray-400 hover:text-gray-200">Home</a>
+            <svg class="fill-current w-3 h-3 mx-3 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
           </li>
           <li class="flex items-center">
-            <span class="text-gray-700">Cloud Services</span>
+            <span class="text-white">Cloud Services</span>
           </li>
         </ol>
       </nav>
-      <h1 class="text-3xl font-bold mb-6">Cloud Services</h1>
+      <h1 class="text-3xl font-bold mb-6 text-white">Cloud Services</h1>
 
       <section class="mb-10">
-        <h2 class="text-2xl font-semibold mb-4 border-b pb-2">Protect your work information</h2>
+        <h2 class="text-2xl font-semibold mb-4 border-b pb-2 text-white">Protect your work information</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Microsoft Entra ID</h3>
-            <a href="posts/cloud_services_microsoft_entra_id.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Microsoft Entra ID</h3>
+            <a href="posts/cloud_services_microsoft_entra_id.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Microsoft Entra Private Access</h3>
-            <a href="posts/cloud_services_microsoft_entra_private_access.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Microsoft Entra Private Access</h3>
+            <a href="posts/cloud_services_microsoft_entra_private_access.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Microsoft Entra Internet Access</h3>
-            <a href="posts/cloud_services_microsoft_entra_internet_access.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Microsoft Entra Internet Access</h3>
+            <a href="posts/cloud_services_microsoft_entra_internet_access.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Azure Attestation Service</h3>
-            <a href="posts/cloud_services_azure_attestation_service.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Azure Attestation Service</h3>
+            <a href="posts/cloud_services_azure_attestation_service.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Microsoft Defender for Endpoint</h3>
-            <a href="posts/cloud_services_microsoft_defender_for_endpoint.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Microsoft Defender for Endpoint</h3>
+            <a href="posts/cloud_services_microsoft_defender_for_endpoint.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Cloud-native device management</h3>
-            <a href="posts/cloud_services_cloud_native_device_management.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Cloud-native device management</h3>
+            <a href="posts/cloud_services_cloud_native_device_management.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Microsoft Intune</h3>
-            <a href="posts/cloud_services_microsoft_intune.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Microsoft Intune</h3>
+            <a href="posts/cloud_services_microsoft_intune.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Windows enrollment attestation</h3>
-            <a href="posts/cloud_services_windows_enrollment_attestation.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Windows enrollment attestation</h3>
+            <a href="posts/cloud_services_windows_enrollment_attestation.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Microsoft Cloud PKI</h3>
-            <a href="posts/cloud_services_microsoft_cloud_pki.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Microsoft Cloud PKI</h3>
+            <a href="posts/cloud_services_microsoft_cloud_pki.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Enterprise Privilege Management (EPM)</h3>
-            <a href="posts/cloud_services_enterprise_privilege_management_epm.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Enterprise Privilege Management (EPM)</h3>
+            <a href="posts/cloud_services_enterprise_privilege_management_epm.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Mobile Application Management (MDM)</h3>
-            <a href="posts/cloud_services_mobile_application_management_mdm.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Mobile Application Management (MDM)</h3>
+            <a href="posts/cloud_services_mobile_application_management_mdm.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
         </div>
       </section>
 
       <section class="mb-10">
-        <h2 class="text-2xl font-semibold mb-4 border-b pb-2">General Cloud Services</h2>
+        <h2 class="text-2xl font-semibold mb-4 border-b pb-2 text-white">General Cloud Services</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Security baselines</h3>
-            <a href="posts/cloud_services_security_baselines.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Security baselines</h3>
+            <a href="posts/cloud_services_security_baselines.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Local Administrator Password Solution (LAPS)</h3>
-            <a href="posts/cloud_services_local_administrator_password_solution_laps.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Local Administrator Password Solution (LAPS)</h3>
+            <a href="posts/cloud_services_local_administrator_password_solution_laps.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Windows Autopilot</h3>
-            <a href="posts/cloud_services_windows_autopilot.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Windows Autopilot</h3>
+            <a href="posts/cloud_services_windows_autopilot.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Windows Update for Business</h3>
-            <a href="posts/cloud_services_windows_update_for_business.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Windows Update for Business</h3>
+            <a href="posts/cloud_services_windows_update_for_business.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Windows Autopatch</h3>
-            <a href="posts/cloud_services_windows_autopatch.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Windows Autopatch</h3>
+            <a href="posts/cloud_services_windows_autopatch.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Windows Hotpatch</h3>
-            <a href="posts/cloud_services_windows_hotpatch.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Windows Hotpatch</h3>
+            <a href="posts/cloud_services_windows_hotpatch.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">OneDrive for work or school</h3>
-            <a href="posts/cloud_services_onedrive_for_work_or_school.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">OneDrive for work or school</h3>
+            <a href="posts/cloud_services_onedrive_for_work_or_school.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Universal Print</h3>
-            <a href="posts/cloud_services_universal_print.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Universal Print</h3>
+            <a href="posts/cloud_services_universal_print.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
         </div>
       </section>
 
       <section class="mb-10">
-        <h2 class="text-2xl font-semibold mb-4 border-b pb-2">Protect your personal information</h2>
+        <h2 class="text-2xl font-semibold mb-4 border-b pb-2 text-white">Protect your personal information</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Microsoft account</h3>
-            <a href="posts/cloud_services_microsoft_account.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Microsoft account</h3>
+            <a href="posts/cloud_services_microsoft_account.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Find my device</h3>
-            <a href="posts/cloud_services_find_my_device.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Find my device</h3>
+            <a href="posts/cloud_services_find_my_device.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">OneDrive for personal use</h3>
-            <a href="posts/cloud_services_onedrive_for_personal_use.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">OneDrive for personal use</h3>
+            <a href="posts/cloud_services_onedrive_for_personal_use.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Family Safety</h3>
-            <a href="posts/cloud_services_family_safety.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Family Safety</h3>
+            <a href="posts/cloud_services_family_safety.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-            <h3 class="text-xl font-semibold mb-2">Personal Vault</h3>
-            <a href="posts/cloud_services_personal_vault.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+          <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+            <h3 class="text-xl font-semibold mb-2 text-white">Personal Vault</h3>
+            <a href="posts/cloud_services_personal_vault.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
           </div>
         </div>
       </section>

--- a/hardware.html
+++ b/hardware.html
@@ -5,85 +5,85 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 text-gray-900">
+<body class="bg-gray-900 text-gray-300">
   <nav class="bg-gray-800 p-4">
     <div class="container mx-auto flex flex-wrap justify-center">
-      <a href="index.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">
+      <a href="index.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-home inline-block w-5 h-5 mr-1 align-text-bottom"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>Home</a>
-      <a href="cloud_services.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
-      <a href="identity.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
-      <a href="application.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
-      <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
-      <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
-      <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
-      <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
+      <a href="cloud_services.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
+      <a href="identity.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
+      <a href="application.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
+      <a href="operating_system.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
+      <a href="hardware.html" class="text-white bg-blue-600 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
+      <a href="security_foundation.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="resources.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
     <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
       <ol class="list-none p-0 inline-flex">
         <li class="flex items-center">
-          <a href="index.html" class="text-gray-500 hover:text-gray-700">Home</a>
-          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+          <a href="index.html" class="text-gray-400 hover:text-gray-200">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
         </li>
         <li class="flex items-center">
-          <span class="text-gray-700">Hardware Security</span>
+          <span class="text-white">Hardware Security</span>
         </li>
       </ol>
     </nav>
     <main>
-      <h1 class="text-3xl font-bold mb-6">Hardware Security</h1>
-      <p class="text-lg mb-6">Explore the various topics related to Hardware Security:</p>
+      <h1 class="text-3xl font-bold mb-6 text-white">Hardware Security</h1>
+      <p class="text-lg mb-6 text-gray-300">Explore the various topics related to Hardware Security:</p>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Configuration Lock</h2>
-          <a href="posts/hardware_configuration_lock.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Configuration Lock</h2>
+          <a href="posts/hardware_configuration_lock.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Direct Memory Access (DMA) Protection</h2>
-          <a href="posts/hardware_direct_memory_access_dma_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Direct Memory Access (DMA) Protection</h2>
+          <a href="posts/hardware_direct_memory_access_dma_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Hardware Enforced Stack Protection</h2>
-          <a href="posts/hardware_hardware_enforced_stack_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Hardware Enforced Stack Protection</h2>
+          <a href="posts/hardware_hardware_enforced_stack_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Hypervisor Enforced Bug Reporting (HEBR)</h2>
-          <a href="posts/hardware_hypervisor_enforced_bug_reporting_hebr.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Hypervisor Enforced Bug Reporting (HEBR)</h2>
+          <a href="posts/hardware_hypervisor_enforced_bug_reporting_hebr.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Hypervisor Protected Code Integrity (HVCI)</h2>
-          <a href="posts/hardware_hypervisor_protected_code_integrity_hvci.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Hypervisor Protected Code Integrity (HVCI)</h2>
+          <a href="posts/hardware_hypervisor_protected_code_integrity_hvci.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Kernel Data Memory Entropy DMA Protection</h2>
-          <a href="posts/hardware_kernel_data_memory_entropy_dma_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Kernel Data Memory Entropy DMA Protection</h2>
+          <a href="posts/hardware_kernel_data_memory_entropy_dma_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Microsoft Secure Process Protections</h2>
-          <a href="posts/hardware_microsoft_secure_process_protections.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Microsoft Secure Process Protections</h2>
+          <a href="posts/hardware_microsoft_secure_process_protections.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Secure Boot</h2>
-          <a href="posts/hardware_secure_boot.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Secure Boot</h2>
+          <a href="posts/hardware_secure_boot.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Trusted Platform Module (TPM) 2.0</h2>
-          <a href="posts/hardware_trusted_platform_module_tpm_2_0.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Trusted Platform Module (TPM) 2.0</h2>
+          <a href="posts/hardware_trusted_platform_module_tpm_2_0.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Virtualization Based Security (VBS)</h2>
-          <a href="posts/hardware_virtualization_based_security_vbs.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Virtualization Based Security (VBS)</h2>
+          <a href="posts/hardware_virtualization_based_security_vbs.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
       </div>

--- a/identity.html
+++ b/identity.html
@@ -5,130 +5,130 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 text-gray-900">
+<body class="bg-gray-900 text-gray-300">
   <nav class="bg-gray-800 p-4">
     <div class="container mx-auto flex flex-wrap justify-center">
-      <a href="index.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">
+      <a href="index.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-home inline-block w-5 h-5 mr-1 align-text-bottom"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>Home</a>
-      <a href="cloud_services.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
-      <a href="identity.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
-      <a href="application.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
-      <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
-      <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
-      <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
-      <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
+      <a href="cloud_services.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
+      <a href="identity.html" class="text-white bg-blue-600 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
+      <a href="application.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
+      <a href="operating_system.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
+      <a href="hardware.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
+      <a href="security_foundation.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="resources.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
     <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
       <ol class="list-none p-0 inline-flex">
         <li class="flex items-center">
-          <a href="index.html" class="text-gray-500 hover:text-gray-700">Home</a>
-          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+          <a href="index.html" class="text-gray-400 hover:text-gray-200">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
         </li>
         <li class="flex items-center">
-          <span class="text-gray-700">Identity</span>
+          <span class="text-white">Identity</span>
         </li>
       </ol>
     </nav>
     <main>
-      <h1 class="text-3xl font-bold mb-6">Identity</h1>
-      <p class="text-lg mb-6">Explore the various topics related to Identity:</p>
+      <h1 class="text-3xl font-bold mb-6 text-white">Identity</h1>
+      <p class="text-lg mb-6 text-gray-300">Explore the various topics related to Identity:</p>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Access Management And Control (UAC)</h2>
-          <a href="posts/identity_access_management_and_control_uac.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Access Management And Control (UAC)</h2>
+          <a href="posts/identity_access_management_and_control_uac.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Account Lockout Policy</h2>
-          <a href="posts/identity_account_lockout_policy.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Account Lockout Policy</h2>
+          <a href="posts/identity_account_lockout_policy.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Azure AD Join</h2>
-          <a href="posts/identity_azure_ad_join.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Azure AD Join</h2>
+          <a href="posts/identity_azure_ad_join.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Credential Guard</h2>
-          <a href="posts/identity_credential_guard.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Credential Guard</h2>
+          <a href="posts/identity_credential_guard.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Enhanced Phishing Protection</h2>
-          <a href="posts/identity_enhanced_phishing_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Enhanced Phishing Protection</h2>
+          <a href="posts/identity_enhanced_phishing_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Enhanced Sign In Security</h2>
-          <a href="posts/identity_enhanced_sign_in_security.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Enhanced Sign In Security</h2>
+          <a href="posts/identity_enhanced_sign_in_security.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">FIDO2</h2>
-          <a href="posts/identity_fido2.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">FIDO2</h2>
+          <a href="posts/identity_fido2.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Microsoft Authenticator</h2>
-          <a href="posts/identity_microsoft_authenticator.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Microsoft Authenticator</h2>
+          <a href="posts/identity_microsoft_authenticator.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Microsoft Privacy Statements And Controls</h2>
-          <a href="posts/identity_microsoft_privacy_statements_and_controls.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Microsoft Privacy Statements And Controls</h2>
+          <a href="posts/identity_microsoft_privacy_statements_and_controls.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Privacy Controls</h2>
-          <a href="posts/identity_privacy_controls.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Privacy Controls</h2>
+          <a href="posts/identity_privacy_controls.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Privacy Resource Usage</h2>
-          <a href="posts/identity_privacy_resource_usage.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Privacy Resource Usage</h2>
+          <a href="posts/identity_privacy_resource_usage.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Remote Credential Guard</h2>
-          <a href="posts/identity_remote_credential_guard.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Remote Credential Guard</h2>
+          <a href="posts/identity_remote_credential_guard.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Smart Card</h2>
-          <a href="posts/identity_smart_card.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Smart Card</h2>
+          <a href="posts/identity_smart_card.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Token Protection</h2>
-          <a href="posts/identity_token_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Token Protection</h2>
+          <a href="posts/identity_token_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">VBS Key Protection</h2>
-          <a href="posts/identity_vbs_key_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">VBS Key Protection</h2>
+          <a href="posts/identity_vbs_key_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Diagnostic Data Processor Configuration</h2>
-          <a href="posts/identity_windows_diagnostic_data_processor_configuration.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Diagnostic Data Processor Configuration</h2>
+          <a href="posts/identity_windows_diagnostic_data_processor_configuration.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Hello</h2>
-          <a href="posts/identity_windows_hello.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Hello</h2>
+          <a href="posts/identity_windows_hello.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Hello For Business</h2>
-          <a href="posts/identity_windows_hello_for_business.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Hello For Business</h2>
+          <a href="posts/identity_windows_hello_for_business.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Webauthn</h2>
-          <a href="posts/identity_webauthn.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Webauthn</h2>
+          <a href="posts/identity_webauthn.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
       </div>

--- a/index.html
+++ b/index.html
@@ -5,63 +5,63 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-white dark:bg-gray-900">
+<body class="bg-gray-900 text-gray-300">
 
-<nav class="bg-white border-gray-200 dark:bg-gray-900">
+<nav class="bg-gray-800 border-gray-700">
   <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
     <a href="index.html" class="flex items-center space-x-3 rtl:space-x-reverse">
-        <span class="self-center text-2xl font-semibold whitespace-nowrap dark:text-white">Windows Security</span>
+        <span class="self-center text-2xl font-semibold whitespace-nowrap text-white">Windows Security</span>
     </a>
-    <button data-collapse-toggle="navbar-default" type="button" class="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600" aria-controls="navbar-default" aria-expanded="false">
+    <button data-collapse-toggle="navbar-default" type="button" class="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-400 rounded-lg md:hidden hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-600" aria-controls="navbar-default" aria-expanded="false">
         <span class="sr-only">Open main menu</span>
         <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 17 14">
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h15M1 7h15M1 13h15"/>
         </svg>
     </button>
     <div class="hidden w-full md:block md:w-auto" id="navbar-default">
-      <ul class="font-medium flex flex-col p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:flex-row md:space-x-8 rtl:space-x-reverse md:mt-0 md:border-0 md:bg-white dark:bg-gray-800 md:dark:bg-gray-900 dark:border-gray-700">
+      <ul class="font-medium flex flex-col p-4 md:p-0 mt-4 border border-gray-700 rounded-lg bg-gray-800 md:flex-row md:space-x-8 rtl:space-x-reverse md:mt-0 md:border-0 md:bg-gray-800">
         <li>
-          <a href="index.html" class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0 dark:text-white md:dark:text-blue-500" aria-current="page">
+          <a href="index.html" class="block py-2 px-3 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-400 md:p-0" aria-current="page">
             <svg class="inline-block w-5 h-5 mr-1 align-text-bottom" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" /><path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /></svg>
             Home
           </a>
         </li>
-        <li><a href="cloud_services.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Cloud Services</a></li>
-        <li><a href="identity.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Identity</a></li>
-        <li><a href="application.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Application</a></li>
-        <li><a href="operating_system.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Operating System</a></li>
-        <li><a href="hardware.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Hardware</a></li>
-        <li><a href="security_foundation.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Security Foundation</a></li>
-        <li><a href="resources.html" class="block py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-white md:dark:hover:bg-transparent">Resources</a></li>
+        <li><a href="cloud_services.html" class="block py-2 px-3 text-gray-300 rounded hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0">Cloud Services</a></li>
+        <li><a href="identity.html" class="block py-2 px-3 text-gray-300 rounded hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0">Identity</a></li>
+        <li><a href="application.html" class="block py-2 px-3 text-gray-300 rounded hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0">Application</a></li>
+        <li><a href="operating_system.html" class="block py-2 px-3 text-gray-300 rounded hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0">Operating System</a></li>
+        <li><a href="hardware.html" class="block py-2 px-3 text-gray-300 rounded hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0">Hardware</a></li>
+        <li><a href="security_foundation.html" class="block py-2 px-3 text-gray-300 rounded hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0">Security Foundation</a></li>
+        <li><a href="resources.html" class="block py-2 px-3 text-gray-300 rounded hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0">Resources</a></li>
       </ul>
     </div>
   </div>
 </nav>
   <div class="container mx-auto max-w-4xl p-6">
     <main>
-      <h1 class="mb-4 text-4xl font-extrabold tracking-tight leading-none text-gray-900 md:text-5xl lg:text-6xl dark:text-white">Comprehensive Windows Security Guide</h1>
-      <p class="mb-6 text-lg font-normal text-gray-500 lg:text-xl dark:text-gray-400">Navigate through our comprehensive guide to understand the diverse layers of Windows security. This site is structured to help you easily find information on protecting your data, identity, applications, and hardware.</p>
+      <h1 class="mb-4 text-4xl font-extrabold tracking-tight leading-none text-white md:text-5xl lg:text-6xl">Comprehensive Windows Security Guide</h1>
+      <p class="mb-6 text-lg font-normal text-gray-300 lg:text-xl">Navigate through our comprehensive guide to understand the diverse layers of Windows security. This site is structured to help you easily find information on protecting your data, identity, applications, and hardware.</p>
 
-      <h2 class="mt-10 mb-4 text-2xl font-bold dark:text-white">Explore Our Security Categories:</h2>
-      <ul class="space-y-4 text-gray-500 list-disc list-inside dark:text-gray-400">
-        <li><strong class="font-semibold text-gray-900 dark:text-white">
-          <svg class="lucide lucide-cloud inline-block w-5 h-5 me-2 text-blue-600 dark:text-blue-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" /></svg>
-          <a href="cloud_services.html" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Cloud Services</a>:</strong> Protection for your work and personal information in the cloud.</li>
-        <li><strong class="font-semibold text-gray-900 dark:text-white">
-          <svg class="lucide lucide-users inline-block w-5 h-5 me-2 text-blue-600 dark:text-blue-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><path d="M16 3.128a4 4 0 0 1 0 7.744" /><path d="M22 21v-2a4 4 0 0 0-3-3.87" /><circle cx="9" cy="7" r="4" /></svg>
-          <a href="identity.html" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Identity</a>:</strong> Managing and securing user identities and access.</li>
-        <li><strong class="font-semibold text-gray-900 dark:text-white">
-          <svg class="lucide lucide-shield inline-block w-5 h-5 me-2 text-blue-600 dark:text-blue-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /></svg>
-          <a href="application.html" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Application Security</a>:</strong> Ensuring applications and drivers are secure and controlled.</li>
-        <li><strong class="font-semibold text-gray-900 dark:text-white">
-          <svg class="lucide lucide-hard-drive inline-block w-5 h-5 me-2 text-blue-600 dark:text-blue-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" x2="2" y1="12" y2="12" /><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" /><line x1="6" x2="6.01" y1="16" y2="16" /><line x1="10" x2="10.01" y1="16" y2="16" /></svg>
-          <a href="operating_system.html" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Operating System Security</a>:</strong> Core security features of the Windows OS, including encryption and network protection.</li>
-        <li><strong class="font-semibold text-gray-900 dark:text-white">
-          <svg class="lucide lucide-cpu inline-block w-5 h-5 me-2 text-blue-600 dark:text-blue-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20v2" /><path d="M12 2v2" /><path d="M17 20v2" /><path d="M17 2v2" /><path d="M2 12h2" /><path d="M2 17h2" /><path d="M2 7h2" /><path d="M20 12h2" /><path d="M20 17h2" /><path d="M20 7h2" /><path d="M7 20v2" /><path d="M7 2v2" /><rect x="4" y="4" width="16" height="16" rx="2" /><rect x="8" y="8" width="8" height="8" rx="1" /></svg>
-          <a href="hardware.html" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Hardware Security</a>:</strong> Security measures built into the physical hardware.</li>
-        <li><strong class="font-semibold text-gray-900 dark:text-white">
-          <svg class="lucide lucide-library inline-block w-5 h-5 me-2 text-blue-600 dark:text-blue-500" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m16 6 4 14" /><path d="M12 6v14" /><path d="M8 8v12" /><path d="M4 4v16" /></svg>
-          <a href="security_foundation.html" class="font-medium text-blue-600 dark:text-blue-500 hover:underline">Security Foundation</a>:</strong> Initiatives, certifications, and supply chain security.</li>
+      <h2 class="mt-10 mb-4 text-2xl font-bold text-white">Explore Our Security Categories:</h2>
+      <ul class="space-y-4 text-gray-300 list-disc list-inside">
+        <li><strong class="font-semibold text-white">
+          <svg class="lucide lucide-cloud inline-block w-5 h-5 me-2 text-blue-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" /></svg>
+          <a href="cloud_services.html" class="font-medium text-blue-400 hover:text-blue-300 hover:underline">Cloud Services</a>:</strong> Protection for your work and personal information in the cloud.</li>
+        <li><strong class="font-semibold text-white">
+          <svg class="lucide lucide-users inline-block w-5 h-5 me-2 text-blue-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><path d="M16 3.128a4 4 0 0 1 0 7.744" /><path d="M22 21v-2a4 4 0 0 0-3-3.87" /><circle cx="9" cy="7" r="4" /></svg>
+          <a href="identity.html" class="font-medium text-blue-400 hover:text-blue-300 hover:underline">Identity</a>:</strong> Managing and securing user identities and access.</li>
+        <li><strong class="font-semibold text-white">
+          <svg class="lucide lucide-shield inline-block w-5 h-5 me-2 text-blue-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /></svg>
+          <a href="application.html" class="font-medium text-blue-400 hover:text-blue-300 hover:underline">Application Security</a>:</strong> Ensuring applications and drivers are secure and controlled.</li>
+        <li><strong class="font-semibold text-white">
+          <svg class="lucide lucide-hard-drive inline-block w-5 h-5 me-2 text-blue-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" x2="2" y1="12" y2="12" /><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" /><line x1="6" x2="6.01" y1="16" y2="16" /><line x1="10" x2="10.01" y1="16" y2="16" /></svg>
+          <a href="operating_system.html" class="font-medium text-blue-400 hover:text-blue-300 hover:underline">Operating System Security</a>:</strong> Core security features of the Windows OS, including encryption and network protection.</li>
+        <li><strong class="font-semibold text-white">
+          <svg class="lucide lucide-cpu inline-block w-5 h-5 me-2 text-blue-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20v2" /><path d="M12 2v2" /><path d="M17 20v2" /><path d="M17 2v2" /><path d="M2 12h2" /><path d="M2 17h2" /><path d="M2 7h2" /><path d="M20 12h2" /><path d="M20 17h2" /><path d="M20 7h2" /><path d="M7 20v2" /><path d="M7 2v2" /><rect x="4" y="4" width="16" height="16" rx="2" /><rect x="8" y="8" width="8" height="8" rx="1" /></svg>
+          <a href="hardware.html" class="font-medium text-blue-400 hover:text-blue-300 hover:underline">Hardware Security</a>:</strong> Security measures built into the physical hardware.</li>
+        <li><strong class="font-semibold text-white">
+          <svg class="lucide lucide-library inline-block w-5 h-5 me-2 text-blue-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m16 6 4 14" /><path d="M12 6v14" /><path d="M8 8v12" /><path d="M4 4v16" /></svg>
+          <a href="security_foundation.html" class="font-medium text-blue-400 hover:text-blue-300 hover:underline">Security Foundation</a>:</strong> Initiatives, certifications, and supply chain security.</li>
       </ul>
     </main>
   </div>

--- a/operating_system.html
+++ b/operating_system.html
@@ -5,185 +5,185 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 text-gray-900">
+<body class="bg-gray-900 text-gray-300">
   <nav class="bg-gray-800 p-4">
     <div class="container mx-auto flex flex-wrap justify-center">
-      <a href="index.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">
+      <a href="index.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-home inline-block w-5 h-5 mr-1 align-text-bottom"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>Home</a>
-      <a href="cloud_services.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
-      <a href="identity.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
-      <a href="application.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
-      <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
-      <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
-      <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
-      <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
+      <a href="cloud_services.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
+      <a href="identity.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
+      <a href="application.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
+      <a href="operating_system.html" class="text-white bg-blue-600 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
+      <a href="hardware.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
+      <a href="security_foundation.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="resources.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
     <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
       <ol class="list-none p-0 inline-flex">
         <li class="flex items-center">
-          <a href="index.html" class="text-gray-500 hover:text-gray-700">Home</a>
-          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+          <a href="index.html" class="text-gray-400 hover:text-gray-200">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
         </li>
         <li class="flex items-center">
-          <span class="text-gray-700">Operating System Security</span>
+          <span class="text-white">Operating System Security</span>
         </li>
       </ol>
     </nav>
     <main>
-      <h1 class="text-3xl font-bold mb-6">Operating System Security</h1>
-      <p class="text-lg mb-6">Explore the various topics related to Operating System Security:</p>
+      <h1 class="text-3xl font-bold mb-6 text-white">Operating System Security</h1>
+      <p class="text-lg mb-6 text-gray-300">Explore the various topics related to Operating System Security:</p>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">5G and eSIM</h2>
-          <a href="posts/operating_system_5g_and_esim.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">5G and eSIM</h2>
+          <a href="posts/operating_system_5g_and_esim.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">BitLocker</h2>
-          <a href="posts/operating_system_bitlocker.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">BitLocker</h2>
+          <a href="posts/operating_system_bitlocker.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">BitLocker To Go</h2>
-          <a href="posts/operating_system_bitlocker_to_go.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">BitLocker To Go</h2>
+          <a href="posts/operating_system_bitlocker_to_go.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Certificates</h2>
-          <a href="posts/operating_system_certificates.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Certificates</h2>
+          <a href="posts/operating_system_certificates.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Code Signing and Integrity</h2>
-          <a href="posts/operating_system_code_signing_and_integrity.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Code Signing and Integrity</h2>
+          <a href="posts/operating_system_code_signing_and_integrity.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Config Refresh</h2>
-          <a href="posts/operating_system_config_refresh.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Config Refresh</h2>
+          <a href="posts/operating_system_config_refresh.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Controlled Folder Access</h2>
-          <a href="posts/operating_system_controlled_folder_access.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Controlled Folder Access</h2>
+          <a href="posts/operating_system_controlled_folder_access.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Cryptography</h2>
-          <a href="posts/operating_system_cryptography.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Cryptography</h2>
+          <a href="posts/operating_system_cryptography.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Device Health Attestation</h2>
-          <a href="posts/operating_system_device_health_attestation.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Device Health Attestation</h2>
+          <a href="posts/operating_system_device_health_attestation.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Domain Name System (DNS) Security</h2>
-          <a href="posts/operating_system_domain_name_system_dns_security.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Domain Name System (DNS) Security</h2>
+          <a href="posts/operating_system_domain_name_system_dns_security.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Email Encryption</h2>
-          <a href="posts/operating_system_email_encryption.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Email Encryption</h2>
+          <a href="posts/operating_system_email_encryption.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Encrypted File System (EFS)</h2>
-          <a href="posts/operating_system_encrypted_file_system_efs.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Encrypted File System (EFS)</h2>
+          <a href="posts/operating_system_encrypted_file_system_efs.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Encrypted Hard Drive</h2>
-          <a href="posts/operating_system_encrypted_hard_drive.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Encrypted Hard Drive</h2>
+          <a href="posts/operating_system_encrypted_hard_drive.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Exploit Protection</h2>
-          <a href="posts/operating_system_exploit_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Exploit Protection</h2>
+          <a href="posts/operating_system_exploit_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Internet Protocol Security (IPSec)</h2>
-          <a href="posts/operating_system_internet_protocol_security_ipsec.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Internet Protocol Security (IPSec)</h2>
+          <a href="posts/operating_system_internet_protocol_security_ipsec.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Kiosk Mode</h2>
-          <a href="posts/operating_system_kiosk_mode.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Kiosk Mode</h2>
+          <a href="posts/operating_system_kiosk_mode.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Microsoft Defender Antivirus</h2>
-          <a href="posts/operating_system_microsoft_defender_antivirus.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Microsoft Defender Antivirus</h2>
+          <a href="posts/operating_system_microsoft_defender_antivirus.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Microsoft Defender Application Guard</h2>
-          <a href="posts/operating_system_microsoft_defender_application_guard.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Microsoft Defender Application Guard</h2>
+          <a href="posts/operating_system_microsoft_defender_application_guard.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Microsoft Defender For Business</h2>
-          <a href="posts/operating_system_microsoft_defender_for_business.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Microsoft Defender For Business</h2>
+          <a href="posts/operating_system_microsoft_defender_for_business.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Network Access Protection</h2>
-          <a href="posts/operating_system_network_access_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Network Access Protection</h2>
+          <a href="posts/operating_system_network_access_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Personal Data Encryption</h2>
-          <a href="posts/operating_system_personal_data_encryption.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Personal Data Encryption</h2>
+          <a href="posts/operating_system_personal_data_encryption.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Rust For Windows</h2>
-          <a href="posts/operating_system_rust_for_windows.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Rust For Windows</h2>
+          <a href="posts/operating_system_rust_for_windows.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Server Message Block (SMB) For Remote Connections</h2>
-          <a href="posts/operating_system_server_message_block_smb_for_remote_connections.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Server Message Block (SMB) For Remote Connections</h2>
+          <a href="posts/operating_system_server_message_block_smb_for_remote_connections.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Tamper Protection</h2>
-          <a href="posts/operating_system_tamper_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Tamper Protection</h2>
+          <a href="posts/operating_system_tamper_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Transport Layer Security (TLS)</h2>
-          <a href="posts/operating_system_transport_layer_security_tls.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Transport Layer Security (TLS)</h2>
+          <a href="posts/operating_system_transport_layer_security_tls.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Wi-Fi Protection</h2>
-          <a href="posts/operating_system_wi_fi_protection.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Wi-Fi Protection</h2>
+          <a href="posts/operating_system_wi_fi_protection.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Firewall</h2>
-          <a href="posts/operating_system_windows_firewall.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Firewall</h2>
+          <a href="posts/operating_system_windows_firewall.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Protected Process</h2>
-          <a href="posts/operating_system_windows_protected_process.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Protected Process</h2>
+          <a href="posts/operating_system_windows_protected_process.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Security App</h2>
-          <a href="posts/operating_system_windows_security_app.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Security App</h2>
+          <a href="posts/operating_system_windows_security_app.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Security Policy Settings And Auditing</h2>
-          <a href="posts/operating_system_windows_security_policy_settings_and_auditing.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Security Policy Settings And Auditing</h2>
+          <a href="posts/operating_system_windows_security_policy_settings_and_auditing.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
       </div>

--- a/resources.html
+++ b/resources.html
@@ -5,40 +5,40 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 text-gray-900">
+<body class="bg-gray-900 text-gray-300">
 <nav class="bg-gray-800 p-4">
   <div class="container mx-auto flex flex-wrap justify-center">
-    <a href="index.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">
+    <a href="index.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-home inline-block w-5 h-5 mr-1 align-text-bottom"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>Home</a>
-    <a href="cloud_services.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
-    <a href="identity.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
-    <a href="application.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
-    <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
-    <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
-    <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
-    <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
+    <a href="cloud_services.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
+    <a href="identity.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
+    <a href="application.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
+    <a href="operating_system.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
+    <a href="hardware.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
+    <a href="security_foundation.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+    <a href="resources.html" class="text-white bg-blue-600 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
   </div>
 </nav>
   <div class="container mx-auto max-w-4xl p-6">
     <main>
-      <h1 class="text-3xl font-bold mb-4">Windows Security Resources</h1>
-      <p class="mb-4">This page provides a curated list of official documentation, helpful websites, and blogs to further your understanding of Windows security and stay up-to-date with the latest information and best practices.</p>
+      <h1 class="text-3xl font-bold mb-4 text-white">Windows Security Resources</h1>
+      <p class="mb-4 text-gray-300">This page provides a curated list of official documentation, helpful websites, and blogs to further your understanding of Windows security and stay up-to-date with the latest information and best practices.</p>
 
-      <h2 class="text-2xl font-bold mb-4">Official Microsoft Resources:</h2>
-      <ul class="list-disc pl-5 space-y-2 mb-4">
-        <li class="mb-2"><a href="https://docs.microsoft.com/en-us/security/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">Microsoft Security Documentation</a> - Comprehensive technical documentation, guidance, and resources for IT professionals and developers on Microsoft security products and services.</li>
-        <li class="mb-2"><a href="https://www.microsoft.com/security/blog/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">Microsoft Security Blog</a> - The official blog for Microsoft security intelligence, insights, and news on threat protection.</li>
-        <li class="mb-2"><a href="https://learn.microsoft.com/en-us/windows/security/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">Windows Security Technical Documentation</a> - Specific documentation related to Windows client and server security features.</li>
+      <h2 class="text-2xl font-bold mb-4 text-white">Official Microsoft Resources:</h2>
+      <ul class="list-disc pl-5 space-y-2 mb-4 text-gray-300">
+        <li class="mb-2"><a href="https://docs.microsoft.com/en-us/security/" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 hover:underline">Microsoft Security Documentation</a> - Comprehensive technical documentation, guidance, and resources for IT professionals and developers on Microsoft security products and services.</li>
+        <li class="mb-2"><a href="https://www.microsoft.com/security/blog/" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 hover:underline">Microsoft Security Blog</a> - The official blog for Microsoft security intelligence, insights, and news on threat protection.</li>
+        <li class="mb-2"><a href="https://learn.microsoft.com/en-us/windows/security/" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 hover:underline">Windows Security Technical Documentation</a> - Specific documentation related to Windows client and server security features.</li>
       </ul>
 
-      <h2 class="text-2xl font-bold mb-4">Government & Non-Profit Resources:</h2>
-      <ul class="list-disc pl-5 space-y-2 mb-4">
-        <li class="mb-2"><a href="https://www.cisa.gov/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">Cybersecurity & Infrastructure Security Agency (CISA)</a> - Part of the U.S. Department of Homeland Security, CISA offers a wealth of information, alerts, and best practices on cybersecurity for individuals and organizations.</li>
-        <li class="mb-2"><a href="https://staysafeonline.org/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">StaySafeOnline.org by National Cybersecurity Alliance</a> - Provides resources and tips to help individuals and businesses stay safe online. Focuses on awareness and education.</li>
-        <li class="mb-2"><a href="https://www.nist.gov/cybersecurity" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">NIST Cybersecurity Resource Center</a> - The National Institute of Standards and Technology (NIST) provides frameworks, standards, and guidelines for cybersecurity. While often technical, it's a foundational resource.</li>
+      <h2 class="text-2xl font-bold mb-4 text-white">Government & Non-Profit Resources:</h2>
+      <ul class="list-disc pl-5 space-y-2 mb-4 text-gray-300">
+        <li class="mb-2"><a href="https://www.cisa.gov/" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 hover:underline">Cybersecurity & Infrastructure Security Agency (CISA)</a> - Part of the U.S. Department of Homeland Security, CISA offers a wealth of information, alerts, and best practices on cybersecurity for individuals and organizations.</li>
+        <li class="mb-2"><a href="https://staysafeonline.org/" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 hover:underline">StaySafeOnline.org by National Cybersecurity Alliance</a> - Provides resources and tips to help individuals and businesses stay safe online. Focuses on awareness and education.</li>
+        <li class="mb-2"><a href="https://www.nist.gov/cybersecurity" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 hover:underline">NIST Cybersecurity Resource Center</a> - The National Institute of Standards and Technology (NIST) provides frameworks, standards, and guidelines for cybersecurity. While often technical, it's a foundational resource.</li>
       </ul>
 
-      <p class="mb-4"><em>Note: External links will open in a new tab. Always ensure you are visiting legitimate websites, especially when seeking security information.</em></p>
+      <p class="mb-4 text-gray-300"><em>Note: External links will open in a new tab. Always ensure you are visiting legitimate websites, especially when seeking security information.</em></p>
     </main>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>

--- a/security_foundation.html
+++ b/security_foundation.html
@@ -5,80 +5,80 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 text-gray-900">
+<body class="bg-gray-900 text-gray-300">
   <nav class="bg-gray-800 p-4">
     <div class="container mx-auto flex flex-wrap justify-center">
-      <a href="index.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">
+      <a href="index.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-home inline-block w-5 h-5 mr-1 align-text-bottom"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>Home</a>
-      <a href="cloud_services.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
-      <a href="identity.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
-      <a href="application.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
-      <a href="operating_system.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
-      <a href="hardware.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
-      <a href="security_foundation.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
-      <a href="resources.html" class="text-white mx-2 px-3 py-2 hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
+      <a href="cloud_services.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Cloud Services</a>
+      <a href="identity.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Identity</a>
+      <a href="application.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Application</a>
+      <a href="operating_system.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Operating System</a>
+      <a href="hardware.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Hardware</a>
+      <a href="security_foundation.html" class="text-white bg-blue-600 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Security Foundation</a>
+      <a href="resources.html" class="text-gray-300 mx-2 px-3 py-2 hover:text-white hover:bg-gray-700 hover:rounded block md:inline-block">Resources</a>
     </div>
   </nav>
   <div class="container mx-auto max-w-4xl p-6">
     <nav class="text-sm font-medium mb-4" aria-label="Breadcrumb">
       <ol class="list-none p-0 inline-flex">
         <li class="flex items-center">
-          <a href="index.html" class="text-gray-500 hover:text-gray-700">Home</a>
-          <svg class="fill-current w-3 h-3 mx-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+          <a href="index.html" class="text-gray-400 hover:text-gray-200">Home</a>
+          <svg class="fill-current w-3 h-3 mx-3 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
         </li>
         <li class="flex items-center">
-          <span class="text-gray-700">Security Foundation</span>
+          <span class="text-white">Security Foundation</span>
         </li>
       </ol>
     </nav>
     <main>
-      <h1 class="text-3xl font-bold mb-6">Security Foundation</h1>
-      <p class="text-lg mb-6">Explore the various topics related to Security Foundation:</p>
+      <h1 class="text-3xl font-bold mb-6 text-white">Security Foundation</h1>
+      <p class="text-lg mb-6 text-gray-300">Explore the various topics related to Security Foundation:</p>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Common Criteria (CC)</h2>
-          <a href="posts/security_foundation_common_criteria_cc.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Common Criteria (CC)</h2>
+          <a href="posts/security_foundation_common_criteria_cc.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">DevDivSecOps</h2>
-          <a href="posts/security_foundation_devdivsecops.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">DevDivSecOps</h2>
+          <a href="posts/security_foundation_devdivsecops.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Federal Information Processing Standard (FIPS)</h2>
-          <a href="posts/security_foundation_federal_information_processing_standard_fips.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Federal Information Processing Standard (FIPS)</h2>
+          <a href="posts/security_foundation_federal_information_processing_standard_fips.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Microsoft Offensive Research And Security Engineering (MORSE)</h2>
-          <a href="posts/security_foundation_microsoft_offensive_research_and_security_engineering_morse.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Microsoft Offensive Research And Security Engineering (MORSE)</h2>
+          <a href="posts/security_foundation_microsoft_offensive_research_and_security_engineering_morse.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Secure Future Initiative (SFI)</h2>
-          <a href="posts/security_foundation_secure_future_initiative_sfi.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Secure Future Initiative (SFI)</h2>
+          <a href="posts/security_foundation_secure_future_initiative_sfi.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Security Development Lifecycle (SDL)</h2>
-          <a href="posts/security_foundation_security_development_lifecycle_sdl.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Security Development Lifecycle (SDL)</h2>
+          <a href="posts/security_foundation_security_development_lifecycle_sdl.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Software Bill Of Materials (SBOM)</h2>
-          <a href="posts/security_foundation_software_bill_of_materials_sbom.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Software Bill Of Materials (SBOM)</h2>
+          <a href="posts/security_foundation_software_bill_of_materials_sbom.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Kernel And Microsoft Bug Bounty Programs</h2>
-          <a href="posts/security_foundation_windows_kernel_and_microsoft_bug_bounty_programs.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Kernel And Microsoft Bug Bounty Programs</h2>
+          <a href="posts/security_foundation_windows_kernel_and_microsoft_bug_bounty_programs.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
-          <h2 class="text-xl font-semibold mb-2">Windows Software Development Kit (SDK)</h2>
-          <a href="posts/security_foundation_windows_software_development_kit_sdk.html" class="text-blue-600 hover:text-blue-800 hover:underline">Read more...</a>
+        <div class="bg-gray-800 p-6 rounded-lg shadow hover:shadow-lg transition-shadow">
+          <h2 class="text-xl font-semibold mb-2 text-white">Windows Software Development Kit (SDK)</h2>
+          <a href="posts/security_foundation_windows_software_development_kit_sdk.html" class="text-blue-400 hover:text-blue-300 hover:underline">Read more...</a>
         </div>
 
       </div>


### PR DESCRIPTION
This commit introduces a consistent dark theme to enhance the visual appeal and user experience of the website.

The following steps were taken:
1. Defined a standard dark theme palette:
    - Background: bg-gray-900 (dark gray)
    - Text: text-gray-300 (light gray)
    - Headings: text-white
    - Links: text-blue-400 (hover: text-blue-300)
    - Navigation: bg-gray-800
2. Systematically updated all HTML files to use this theme:
    - index.html
    - application.html
    - cloud_services.html
    - hardware.html
    - identity.html
    - operating_system.html
    - resources.html
    - security_foundation.html
3. Modified Tailwind CSS classes to apply the theme to body, navigation, headings, paragraphs, links, breadcrumbs, and content cards.
4. Removed existing `dark:` variant classes as the dark theme is now the default.
5. Ensured active navigation links are appropriately highlighted.
6. Conceptually reviewed all pages to ensure consistency of the applied theme.