### PR TITLE
Refactor: Make 'learn more' link smaller on timeline

### DIFF
--- a/timeline.js
+++ b/timeline.js
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 learnMoreLink.href = vuln.details_url;
                 learnMoreLink.target = '_blank';
                 learnMoreLink.rel = 'noopener noreferrer';
-                learnMoreLink.className = 'inline-flex items-center px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:outline-none focus:ring-gray-100 focus:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 dark:focus:ring-gray-700';
+                learnMoreLink.className = 'inline-flex items-center px-4 py-2 text-xs font-medium text-gray-900 bg-white border border-gray-200 rounded-lg hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:outline-none focus:ring-gray-100 focus:text-blue-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700 dark:focus:ring-gray-700';
                 learnMoreLink.innerHTML = 'Learn more <svg class="w-3 h-3 ms-2 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5h12m0 0L9 1m4 4L9 9"/></svg>';
 
                 listItem.appendChild(timePoint);


### PR DESCRIPTION
The 'learn more' link on the timeline view was using the `text-sm` Tailwind CSS class. This change updates it to `text-xs` to make the link text smaller, as per the issue.

The change was verified by visual inspection in a browser.