### PR TITLE
Refactor: Move 'Learn More' button into expandable summary

### DIFF
--- a/timeline.js
+++ b/timeline.js
@@ -98,7 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 listItem.appendChild(timePoint);
                 listItem.appendChild(title);
                 listItem.appendChild(summaryDiv); // Add summary div (initially hidden)
-                listItem.appendChild(learnMoreLink);
+                summaryDiv.appendChild(learnMoreLink); // Appended to summaryDiv
                 vulnerabilitiesList.appendChild(listItem);
             });
             yearSection.appendChild(vulnerabilitiesList);


### PR DESCRIPTION
The 'Learn More' button on the timeline page is now located within the expandable summary section of each timeline item.

This change ensures that the button is only visible when you expand an event's summary, reducing clutter in the default timeline view. The button's functionality and link remain unchanged.