### PR TITLE
Refactor: Make search bar always visible and inline with navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,16 +18,9 @@
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h15M1 7h15M1 13h15"/>
         </svg>
     </button>
-    <div class="hidden w-full md:block md:w-auto" id="navbar-default">
-      <!-- Search Icon Button -->
-      <button type="button" id="search-toggle-button" class="p-2 text-gray-500 rounded-lg hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600 md:ml-4">
-        <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-          <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
-        </svg>
-        <span class="sr-only">Open search</span>
-      </button>
-      <!-- Search Input Container (initially hidden) -->
-      <div id="search-input-container" class="hidden relative mt-3 md:mt-0 md:ml-2">
+    <div class="hidden w-full md:block md:w-auto md:items-center" id="navbar-default">
+      <!-- Search Input Container -->
+      <div id="search-input-container" class="relative mt-3 md:mt-0 md:ml-4">
         <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
           <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>

--- a/search.js
+++ b/search.js
@@ -8,12 +8,12 @@ document.addEventListener('DOMContentLoaded', function () {
     return;
   }
 
-  searchToggleButton.addEventListener('click', function() {
-    searchInputContainer.classList.toggle('hidden');
-    if (!searchInputContainer.classList.contains('hidden')) {
-      searchInput.focus();
-    }
-  });
+  // searchToggleButton.addEventListener('click', function() {
+  //   searchInputContainer.classList.toggle('hidden');
+  //   if (!searchInputContainer.classList.contains('hidden')) {
+  //     searchInput.focus();
+  //   }
+  // });
 
   const searchableContent = Array.from(document.querySelectorAll('main h1, main h2, main p, main li, main td, main th, main span, main a'));
 


### PR DESCRIPTION
I modified `index.html` to reposition the search input container directly within the main navigation bar flow, making it always visible. I also removed the search toggle button.

I updated `search.js` to comment out the toggle functionality as it's no longer required.

Tailwind CSS classes were adjusted to ensure proper alignment and spacing of the search bar with other navigation elements. No custom CSS changes were needed.