### PR TITLE
Fix: Improve dark mode readability for posts.

### DIFF
--- a/post_template.html
+++ b/post_template.html
@@ -23,7 +23,7 @@
       #markdown-content h6 { @apply text-base; }
 
       #markdown-content p {
-        @apply text-gray-700 dark:text-gray-300 mb-4 leading-relaxed text-lg;
+        @apply text-gray-700 dark:text-gray-100 mb-4 leading-relaxed text-lg;
       }
 
       #markdown-content a {
@@ -61,10 +61,10 @@
       }
 
       #markdown-content table {
-        @apply w-full mb-4 text-left text-sm text-gray-500 dark:text-gray-400 border-collapse;
+        @apply w-full mb-4 text-left text-sm text-gray-500 dark:text-gray-200 border-collapse;
       }
       #markdown-content table thead {
-        @apply text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400;
+        @apply text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-200;
       }
       #markdown-content table th,
       #markdown-content table td {


### PR DESCRIPTION
This commit addresses issues with text being too dark on a dark background within the markdown content of posts.

Key changes in `post_template.html`:
- Paragraph text color in dark mode changed from `dark:text-gray-300` to `dark:text-gray-100` for better contrast.
- Table text color (both header and body) in dark mode changed from `dark:text-gray-400` to `dark:text-gray-200` for improved legibility.

These changes ensure that post content, including headings, paragraphs, and tables, is clearly readable when using the dark theme.