### PR TITLE
Improve styling and fonts for Markdown posts

### DIFF
--- a/post_template.html
+++ b/post_template.html
@@ -5,8 +5,12 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <title>Windows Security - Post</title>
     <style>
+      body {
+        font-family: 'Inter', sans-serif; /* Apply Inter as the base font */
+      }
       #markdown-content h1,
       #markdown-content h2,
       #markdown-content h3,
@@ -50,14 +54,15 @@
       }
 
       #markdown-content pre {
-        @apply bg-gray-100 dark:bg-gray-800 p-4 rounded-md shadow-sm overflow-x-auto mb-4 text-sm;
+        @apply bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 p-4 rounded-md shadow-sm overflow-x-auto mb-4 text-sm font-mono;
       }
       #markdown-content code { /* For inline code */
-        @apply bg-gray-200 dark:bg-gray-700 text-red-600 dark:text-red-400 px-1 py-0.5 rounded-sm text-sm;
+        @apply bg-pink-100 dark:bg-pink-900 text-pink-700 dark:text-pink-300 px-1.5 py-1 rounded-md text-sm font-mono;
       }
       #markdown-content pre code { /* Reset for code inside pre, as pre already has styling */
-        @apply bg-transparent text-inherit p-0 rounded-none dark:text-inherit;
-        font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+        @apply bg-transparent p-0 rounded-none;
+        font-family: inherit; /* Inherit font-family (mono) from pre tag */
+        /* Color will also be inherited from pre tag */
       }
 
       #markdown-content table {


### PR DESCRIPTION
This commit enhances the visual presentation of Markdown-based posts:

- Updated CSS in `post_template.html` to refine the styling of various Markdown elements, with specific improvements to code blocks and inline code for better clarity and visual appeal. Tailwind's @apply directive is used extensively to maintain consistency.
- Introduced the 'Inter' web font as the base font for post pages, improving overall readability and providing a more polished look. This is applied via Google Fonts in `post_template.html`.
- Ensured that all styles are compatible with dark mode and maintain consistency with the existing site theme.
- Verified that container styling for posts provides appropriate width and padding for readability.