### PR TITLE
Fix: Ensure case-insensitive matching for post filenames

### DIFF
--- a/post_template.html
+++ b/post_template.html
@@ -173,13 +173,14 @@
     // This is a client-side check and real security would need server-side validation if paths were more complex.
     // For this static site context, it primarily prevents malformed URLs.
     const sanitizedPostName = postName.replace(/[^a-zA-Z0-9-_]/g, '');
+    const lowerCasePostName = sanitizedPostName.toLowerCase();
     if (sanitizedPostName !== postName) {
         contentElement.innerHTML = '<p class="text-red-500">Error: Invalid characters in post name.</p>';
         document.title = 'Error - Windows Security';
         return;
     }
 
-    const mdFilePath = `posts/md/${sanitizedPostName}.md`;
+    const mdFilePath = `posts/md/${lowerCasePostName}.md`;
 
     fetch(mdFilePath)
       .then(response => {
@@ -195,7 +196,7 @@
           document.title = h1Match[1] + " - Windows Security";
         } else {
           // Fallback title if no H1 is found
-          const titleFriendlyPostName = sanitizedPostName.replace(/-/g, ' ').replace(/_/g, ' ');
+          const titleFriendlyPostName = lowerCasePostName.replace(/-/g, ' ').replace(/_/g, ' ');
           function capitalizeWords(str) {
             return str.toLowerCase().replace(/\b\w/g, char => char.toUpperCase());
           }
@@ -215,7 +216,7 @@
       })
       .catch(error => {
         console.error('Error fetching or parsing Markdown:', error);
-        contentElement.innerHTML = `<p class="text-red-500">Error loading post: ${sanitizedPostName}.md. ${error.message}. Make sure the file exists in the 'posts/md/' directory.</p>`;
+        contentElement.innerHTML = `<p class="text-red-500">Error loading post: ${lowerCasePostName}.md. ${error.message}. Make sure the file exists in the 'posts/md/' directory.</p>`;
         document.title = 'Post Not Found - Windows Security';
       });
   });


### PR DESCRIPTION
I modified `post_template.html` to convert the sanitized post name from the URL parameter to lowercase before attempting to fetch the corresponding markdown file.

This resolves an issue where posts linked with URLs containing uppercase characters in their names would fail to load on case-sensitive file systems. The failure to load the markdown content into the designated element prevented CSS styles from being applied.

The changes include:
- Converting the sanitized post name to lowercase.
- Using this lowercase name for constructing the markdown file path.
- Using the lowercase name in error messages for consistency.
- Using the lowercase name for generating fallback page titles.