### PR TITLE
feat: Display 'Last Updated' date for Markdown posts

### DIFF
--- a/post_template.html
+++ b/post_template.html
@@ -151,6 +151,7 @@
   </div>
 </nav>
 <div class="container mx-auto max-w-4xl p-6">
+  <div id="last-updated-container" class="text-sm text-gray-500 dark:text-gray-400 mb-4"></div>
   <main id="markdown-content">
     <!-- Markdown content will be loaded here -->
   </main>
@@ -211,7 +212,36 @@
         //   console.warn('DOMPurify not loaded. HTML will not be sanitized.');
         //   contentElement.innerHTML = marked.parse(markdown);
         // }
-        contentElement.innerHTML = marked.parse(markdown);
+
+        // Fetch last-modified header
+        fetch(mdFilePath, { method: 'HEAD' })
+          .then(response => {
+            if (response.ok) {
+              const lastModified = response.headers.get('Last-Modified');
+              if (lastModified) {
+                const lastUpdatedDate = new Date(lastModified);
+                const formattedDate = lastUpdatedDate.toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric'
+                });
+                const lastUpdatedContainer = document.getElementById('last-updated-container');
+                if (lastUpdatedContainer) {
+                  lastUpdatedContainer.textContent = "Last Updated: " + formattedDate;
+                }
+              } else {
+                console.warn('Last-Modified header not found.');
+              }
+            }
+          })
+          .catch(headerError => {
+            // Log error fetching header, but don't block content rendering
+            console.warn('Could not fetch Last-Modified header:', headerError);
+          })
+          .finally(() => {
+            // Render markdown content regardless of header fetch success/failure
+            contentElement.innerHTML = marked.parse(markdown);
+          });
       })
       .catch(error => {
         console.error('Error fetching or parsing Markdown:', error);


### PR DESCRIPTION
Adds a 'Last Updated' date to the post template.

This feature modifies `post_template.html` to:
- Add a dedicated `div` to display the last updated information.
- Fetch the `Last-Modified` header of the Markdown file using a 'HEAD' request.
- If the header is available, format the date and display it above the post content.
- Ensure that the post content still loads even if the last modified date cannot be retrieved.

This helps you understand the timeliness of the information presented in posts.