### PR TITLE
Fix: Remove missing search.js and address Tailwind CSS CDN usage

### DIFF
--- a/application.html
+++ b/application.html
@@ -4,7 +4,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Application Security - Windows Security</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!--
+   IMPORTANT: The Tailwind CSS CDN (https://cdn.tailwindcss.com) is not recommended for production use.
+   It's recommended to install Tailwind CSS as a PostCSS plugin or use the Tailwind CLI to generate a static CSS file.
+   Please see https://tailwindcss.com/docs/installation for instructions.
+   You will then need to link to your generated CSS file, typically like this:
+   <link href="/path/to/your/tailwind.css" rel="stylesheet">
+   -->
 </head>
 <body class="bg-white dark:bg-gray-900">
 

--- a/cloud_services.html
+++ b/cloud_services.html
@@ -4,7 +4,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cloud Services - Windows Security</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!--
+   IMPORTANT: The Tailwind CSS CDN (https://cdn.tailwindcss.com) is not recommended for production use.
+   It's recommended to install Tailwind CSS as a PostCSS plugin or use the Tailwind CLI to generate a static CSS file.
+   Please see https://tailwindcss.com/docs/installation for instructions.
+   You will then need to link to your generated CSS file, typically like this:
+   <link href="/path/to/your/tailwind.css" rel="stylesheet">
+   -->
 </head>
 <body class="bg-white dark:bg-gray-900">
 

--- a/hardware.html
+++ b/hardware.html
@@ -4,7 +4,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hardware Security - Windows Security</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!--
+   IMPORTANT: The Tailwind CSS CDN (https://cdn.tailwindcss.com) is not recommended for production use.
+   It's recommended to install Tailwind CSS as a PostCSS plugin or use the Tailwind CLI to generate a static CSS file.
+   Please see https://tailwindcss.com/docs/installation for instructions.
+   You will then need to link to your generated CSS file, typically like this:
+   <link href="/path/to/your/tailwind.css" rel="stylesheet">
+   -->
 </head>
 <body class="bg-white dark:bg-gray-900">
 

--- a/identity.html
+++ b/identity.html
@@ -4,7 +4,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Identity - Windows Security</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!--
+   IMPORTANT: The Tailwind CSS CDN (https://cdn.tailwindcss.com) is not recommended for production use.
+   It's recommended to install Tailwind CSS as a PostCSS plugin or use the Tailwind CLI to generate a static CSS file.
+   Please see https://tailwindcss.com/docs/installation for instructions.
+   You will then need to link to your generated CSS file, typically like this:
+   <link href="/path/to/your/tailwind.css" rel="stylesheet">
+   -->
 </head>
 <body class="bg-white dark:bg-gray-900">
 

--- a/operating_system.html
+++ b/operating_system.html
@@ -4,7 +4,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Operating System Security - Windows Security</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!--
+   IMPORTANT: The Tailwind CSS CDN (https://cdn.tailwindcss.com) is not recommended for production use.
+   It's recommended to install Tailwind CSS as a PostCSS plugin or use the Tailwind CLI to generate a static CSS file.
+   Please see https://tailwindcss.com/docs/installation for instructions.
+   You will then need to link to your generated CSS file, typically like this:
+   <link href="/path/to/your/tailwind.css" rel="stylesheet">
+   -->
 </head>
 <body class="bg-white dark:bg-gray-900">
 

--- a/post_template.html
+++ b/post_template.html
@@ -3,7 +3,13 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
-    <script src="https://cdn.tailwindcss.com"></script>
+    <!--
+   IMPORTANT: The Tailwind CSS CDN (https://cdn.tailwindcss.com) is not recommended for production use.
+   It's recommended to install Tailwind CSS as a PostCSS plugin or use the Tailwind CLI to generate a static CSS file.
+   Please see https://tailwindcss.com/docs/installation for instructions.
+   You will then need to link to your generated CSS file, typically like this:
+   <link href="/path/to/your/tailwind.css" rel="stylesheet">
+   -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <title>Windows Security - Post</title>
@@ -136,17 +142,6 @@
           <a href="resources.html" class="flex items-center justify-between w-full py-2 px-3 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0 md:w-auto dark:text-white md:dark:hover:text-blue-500 dark:focus:text-white dark:border-gray-700 dark:hover:bg-gray-700 md:dark:hover:bg-transparent">Resources</a>
         </li>
       </ul>
-      <button type="button" id="search-toggle-button" class="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 md:ml-4">
-        <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/></svg>
-      </button>
-      <div id="search-input-container" class="relative md:ml-2 transition-all duration-300 ease-in-out opacity-0 w-0 overflow-hidden pointer-events-none">
-        <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
-          <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
-          </svg>
-        </div>
-        <input type="text" id="search-navbar" class="block w-full p-2 ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Search...">
-      </div>
     </div>
   </div>
 </nav>
@@ -157,7 +152,6 @@
   </main>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
-<script src="search.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     const contentElement = document.getElementById('markdown-content');

--- a/resources.html
+++ b/resources.html
@@ -4,7 +4,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Windows Security - Resources</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!--
+   IMPORTANT: The Tailwind CSS CDN (https://cdn.tailwindcss.com) is not recommended for production use.
+   It's recommended to install Tailwind CSS as a PostCSS plugin or use the Tailwind CLI to generate a static CSS file.
+   Please see https://tailwindcss.com/docs/installation for instructions.
+   You will then need to link to your generated CSS file, typically like this:
+   <link href="/path/to/your/tailwind.css" rel="stylesheet">
+   -->
 </head>
 <body class="bg-white dark:bg-gray-900">
 

--- a/security_foundation.html
+++ b/security_foundation.html
@@ -4,7 +4,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Security Foundation - Windows Security</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" rel="stylesheet" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <!--
+   IMPORTANT: The Tailwind CSS CDN (https://cdn.tailwindcss.com) is not recommended for production use.
+   It's recommended to install Tailwind CSS as a PostCSS plugin or use the Tailwind CLI to generate a static CSS file.
+   Please see https://tailwindcss.com/docs/installation for instructions.
+   You will then need to link to your generated CSS file, typically like this:
+   <link href="/path/to/your/tailwind.css" rel="stylesheet">
+   -->
 </head>
 <body class="bg-white dark:bg-gray-900">
 


### PR DESCRIPTION
- I removed the reference to the non-existent `search.js` from `post_template.html` to resolve 404 errors.
- I also removed the associated non-functional search UI elements from `post_template.html`.

- I removed the Tailwind CSS CDN script (`https://cdn.tailwindcss.com`) from all HTML files because it is not recommended for production.
- I added HTML comments in place of the CDN script in all affected files, guiding you to install Tailwind CSS locally using the CLI or as a PostCSS plugin for production use, per Tailwind documentation. The site's Tailwind styling will be temporarily unavailable until you take these steps.