### PR TITLE
Add table of contents to blog posts

### DIFF
--- a/post_template.html
+++ b/post_template.html
@@ -73,6 +73,7 @@
 </nav>
 <div class="container mx-auto max-w-4xl p-6">
   <div id="last-updated-container" class="text-sm text-gray-600 dark:text-gray-400 mb-6"></div>
+  <div id="toc-container"></div>
   <main id="markdown-content">
     <!-- Markdown content will be loaded here -->
   </main>
@@ -162,6 +163,60 @@
           .finally(() => {
             // Render markdown content regardless of header fetch success/failure
             contentElement.innerHTML = marked.parse(markdown);
+
+            // TOC Generation
+            const tocContainer = document.getElementById('toc-container');
+            if (tocContainer) {
+                const headings = contentElement.querySelectorAll('h1, h2, h3, h4, h5, h6');
+                if (headings.length > 0) {
+                    const tocList = document.createElement('ul');
+                    // Add a title for the TOC
+                    const tocTitle = document.createElement('h2');
+                    tocTitle.textContent = 'Table of Contents';
+                    tocTitle.classList.add('text-xl', 'font-semibold', 'mb-2', 'dark:text-white'); // Tailwind classes for styling
+                    tocContainer.appendChild(tocTitle);
+
+                    headings.forEach((heading, index) => {
+                        let id = heading.id;
+                        if (!id) {
+                            // Generate an ID from the text content
+                            id = heading.textContent.trim().toLowerCase()
+                                .replace(/\s+/g, '-') // Replace spaces with hyphens
+                                .replace(/[^\w-]+/g, ''); // Remove non-alphanumeric characters except hyphens
+                            // Ensure uniqueness if multiple headings have the same text
+                            let uniqueId = id;
+                            let counter = 1;
+                            while (document.getElementById(uniqueId)) {
+                                uniqueId = `${id}-${counter}`;
+                                counter++;
+                            }
+                            id = uniqueId;
+                            heading.id = id;
+                        }
+
+                        const listItem = document.createElement('li');
+                        const link = document.createElement('a');
+                        link.href = `#${id}`;
+                        link.textContent = heading.textContent;
+                        // Add Tailwind classes for styling based on heading level
+                        const level = parseInt(heading.tagName.substring(1));
+                        link.classList.add('hover:underline', 'dark:text-gray-300', 'text-gray-700'); // Common link styles
+                        if (level === 1) {
+                            link.classList.add('font-semibold');
+                        } else if (level === 2) {
+                            link.classList.add('ml-2');
+                        } else if (level === 3) {
+                            link.classList.add('ml-4');
+                        } else if (level >= 4) {
+                            link.classList.add('ml-6');
+                        }
+
+                        listItem.appendChild(link);
+                        tocList.appendChild(listItem);
+                    });
+                    tocContainer.appendChild(tocList);
+                }
+            }
           });
       })
       .catch(error => {

--- a/styles.css
+++ b/styles.css
@@ -290,3 +290,48 @@ body {
 .dark #markdown-content img {
   border-color: #374151; /* dark:border-gray-700 */
 }
+
+/* Table of Contents Styles */
+#toc-container {
+  border: 1px solid #D1D5DB; /* border-gray-300 */
+  padding: 1.25rem; /* p-5 */
+  border-radius: 0.375rem; /* rounded-md */
+  margin-bottom: 1.5rem; /* mb-6 */
+  background-color: #F9FAFB; /* bg-gray-50 */
+}
+
+.dark #toc-container {
+  border-color: #4B5563; /* dark:border-gray-600 */
+  background-color: #1F2937; /* dark:bg-gray-800 */
+}
+
+/* The TOC title (h2) is styled by Tailwind classes in the JS (text-xl, font-semibold, mb-2, dark:text-white).
+   No additional CSS is added here for the title to keep styling centralized in JS for it. */
+
+#toc-container ul {
+  list-style-type: none;
+  padding-left: 0; /* Reset browser default */
+  margin-top: 0.75rem; /* mt-3, space below the title */
+}
+
+#toc-container li {
+  margin-bottom: 0.5rem; /* mb-2 */
+}
+
+/* Links are primarily styled by Tailwind classes added in JavaScript (color, hover, indentation).
+   The following are minimal additions/overrides. */
+#toc-container a {
+  font-family: 'Inter', sans-serif; /* Ensure consistent font */
+  font-size: 0.95rem; /* Slightly smaller than main text for visual hierarchy */
+  /* text-decoration: none; -- Removing this as Tailwind's hover:underline is preferred */
+}
+
+/* Example: If you wanted a specific non-Tailwind hover effect for TOC links:
+#toc-container a:hover {
+  text-decoration: underline;
+  color: #1D4ED8; // Example: darker blue on hover
+}
+.dark #toc-container a:hover {
+  color: #93C5FD; // Example: lighter blue on hover in dark mode
+}
+*/


### PR DESCRIPTION
This feature automatically generates a table of contents for each blog post, making it easier for you to navigate long posts.

The implementation involves:
- Modifying `post_template.html` to include a placeholder for the TOC.
- Adding JavaScript to `post_template.html` to:
    - Identify headings (h1-h6) in the post content.
    - Generate unique IDs for headings if they don't exist.
    - Create links to these headings.
    - Populate the TOC container with these links.
- Adding CSS styles to `styles.css` for the TOC's appearance, including dark mode support.