### PR TITLE
feat: Implement post previews on category pages

### DIFF
--- a/application.html
+++ b/application.html
@@ -82,51 +82,61 @@
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Applocker</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Browser Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Defender Application Guard</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Vulnerable Driver Block</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Smart App Control</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Trusted Signing</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Virtualization Based Integrity (VBI)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Sandbox</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Subsystem For Linux (WSL)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">WSL App Isolation</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
@@ -134,5 +144,63 @@
     </main>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    function loadPostPreviews() {
+      const postContainers = document.querySelectorAll('.grid > div.bg-white');
+      postContainers.forEach(container => {
+        const postLink = container.querySelector('a[href*="post_template.html?post="]');
+        const previewElement = container.querySelector('.post-preview-text');
+
+        if (postLink && previewElement) {
+          const href = postLink.getAttribute('href');
+          const urlParams = new URLSearchParams(href.split('?')[1]);
+          const postName = urlParams.get('post');
+
+          if (postName) {
+            const markdownFilePath = `posts/md/${postName}.md`;
+            fetch(markdownFilePath)
+              .then(response => {
+                if (!response.ok) {
+                  throw new Error(`HTTP error! status: ${response.status} for ${markdownFilePath}`);
+                }
+                return response.text();
+              })
+              .then(markdown => {
+                if (typeof marked === 'undefined') {
+                  console.error('marked.js is not loaded.');
+                  previewElement.textContent = "Error: Markdown parser not loaded.";
+                  return;
+                }
+                const html = marked.parse(markdown);
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = html;
+                const firstParagraph = tempDiv.querySelector('p');
+
+                if (firstParagraph) {
+                  let previewText = firstParagraph.textContent || firstParagraph.innerText || "";
+                  if (previewText.length > 200) {
+                    previewText = previewText.substring(0, 200).trim() + "...";
+                  }
+                  previewElement.textContent = previewText;
+                } else {
+                  previewElement.textContent = "No preview available.";
+                }
+              })
+              .catch(error => {
+                console.error('Error fetching or parsing markdown:', error);
+                previewElement.textContent = "Preview not found or error loading.";
+              });
+          } else {
+            // If postName is not found, it implies the link is not for a post or is malformed.
+            // previewElement.textContent = "Not a post link.";
+            // previewElement.style.display = 'none'; // Or hide it
+          }
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', loadPostPreviews);
+  </script>
 </body>
 </html>

--- a/cloud_services.html
+++ b/cloud_services.html
@@ -84,7 +84,8 @@
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
           <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
             <h3 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Entra ID</h3>
-            <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
+            <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
+            <a href="post_template.html?post=sample-markdown-post" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
           </div>
           <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
             <h3 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Entra Private Access</h3>
@@ -196,5 +197,64 @@
     </main>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    function loadPostPreviews() {
+      const postContainers = document.querySelectorAll('.grid > div.bg-white');
+      postContainers.forEach(container => {
+        const postLink = container.querySelector('a[href*="post_template.html?post="]');
+        const previewElement = container.querySelector('.post-preview-text');
+
+        if (postLink && previewElement) {
+          const href = postLink.getAttribute('href');
+          const urlParams = new URLSearchParams(href.split('?')[1]);
+          const postName = urlParams.get('post');
+
+          if (postName) {
+            const markdownFilePath = `posts/md/${postName}.md`;
+            fetch(markdownFilePath)
+              .then(response => {
+                if (!response.ok) {
+                  throw new Error(`HTTP error! status: ${response.status} for ${markdownFilePath}`);
+                }
+                return response.text();
+              })
+              .then(markdown => {
+                if (typeof marked === 'undefined') {
+                  console.error('marked.js is not loaded.');
+                  previewElement.textContent = "Error: Markdown parser not loaded.";
+                  return;
+                }
+                const html = marked.parse(markdown);
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = html;
+                const firstParagraph = tempDiv.querySelector('p');
+
+                if (firstParagraph) {
+                  let previewText = firstParagraph.textContent || firstParagraph.innerText || "";
+                  if (previewText.length > 200) {
+                    previewText = previewText.substring(0, 200).trim() + "...";
+                  }
+                  previewElement.textContent = previewText;
+                } else {
+                  previewElement.textContent = "No preview available.";
+                }
+              })
+              .catch(error => {
+                console.error('Error fetching or parsing markdown:', error);
+                previewElement.textContent = "Preview not found or error loading.";
+              });
+          } else {
+            // If postName is not found, it implies the link is not for a post or is malformed.
+            // We can choose to hide the preview element or set a specific message.
+            // previewElement.textContent = "Not a post link.";
+            // previewElement.style.display = 'none'; // Or hide it
+          }
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', loadPostPreviews);
+  </script>
 </body>
 </html>

--- a/hardware.html
+++ b/hardware.html
@@ -82,51 +82,61 @@
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Configuration Lock</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Direct Memory Access (DMA) Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Hardware Enforced Stack Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Hypervisor Enforced Bug Reporting (HEBR)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Hypervisor Protected Code Integrity (HVCI)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Kernel Data Memory Entropy DMA Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Secure Process Protections</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Secure Boot</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Trusted Platform Module (TPM) 2.0</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Virtualization Based Security (VBS)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
@@ -134,5 +144,63 @@
     </main>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    function loadPostPreviews() {
+      const postContainers = document.querySelectorAll('.grid > div.bg-white');
+      postContainers.forEach(container => {
+        const postLink = container.querySelector('a[href*="post_template.html?post="]');
+        const previewElement = container.querySelector('.post-preview-text');
+
+        if (postLink && previewElement) {
+          const href = postLink.getAttribute('href');
+          const urlParams = new URLSearchParams(href.split('?')[1]);
+          const postName = urlParams.get('post');
+
+          if (postName) {
+            const markdownFilePath = `posts/md/${postName}.md`;
+            fetch(markdownFilePath)
+              .then(response => {
+                if (!response.ok) {
+                  throw new Error(`HTTP error! status: ${response.status} for ${markdownFilePath}`);
+                }
+                return response.text();
+              })
+              .then(markdown => {
+                if (typeof marked === 'undefined') {
+                  console.error('marked.js is not loaded.');
+                  previewElement.textContent = "Error: Markdown parser not loaded.";
+                  return;
+                }
+                const html = marked.parse(markdown);
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = html;
+                const firstParagraph = tempDiv.querySelector('p');
+
+                if (firstParagraph) {
+                  let previewText = firstParagraph.textContent || firstParagraph.innerText || "";
+                  if (previewText.length > 200) {
+                    previewText = previewText.substring(0, 200).trim() + "...";
+                  }
+                  previewElement.textContent = previewText;
+                } else {
+                  previewElement.textContent = "No preview available.";
+                }
+              })
+              .catch(error => {
+                console.error('Error fetching or parsing markdown:', error);
+                previewElement.textContent = "Preview not found or error loading.";
+              });
+          } else {
+            // If postName is not found, it implies the link is not for a post or is malformed.
+            // previewElement.textContent = "Not a post link.";
+            // previewElement.style.display = 'none'; // Or hide it
+          }
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', loadPostPreviews);
+  </script>
 </body>
 </html>

--- a/identity.html
+++ b/identity.html
@@ -82,96 +82,115 @@
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Access Management And Control (UAC)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="post_template.html?post=identity_access_management_and_control_uac" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more...</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Account Lockout Policy</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Azure AD Join</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Credential Guard</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Enhanced Phishing Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Enhanced Sign In Security</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">FIDO2</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Authenticator</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Privacy Statements And Controls</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Privacy Controls</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Privacy Resource Usage</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Remote Credential Guard</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Smart Card</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Token Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">VBS Key Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Diagnostic Data Processor Configuration</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Hello</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Hello For Business</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Webauthn</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
@@ -179,5 +198,63 @@
     </main>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    function loadPostPreviews() {
+      const postContainers = document.querySelectorAll('.grid > div.bg-white');
+      postContainers.forEach(container => {
+        const postLink = container.querySelector('a[href*="post_template.html?post="]');
+        const previewElement = container.querySelector('.post-preview-text');
+
+        if (postLink && previewElement) {
+          const href = postLink.getAttribute('href');
+          const urlParams = new URLSearchParams(href.split('?')[1]);
+          const postName = urlParams.get('post');
+
+          if (postName) {
+            const markdownFilePath = `posts/md/${postName}.md`;
+            fetch(markdownFilePath)
+              .then(response => {
+                if (!response.ok) {
+                  throw new Error(`HTTP error! status: ${response.status} for ${markdownFilePath}`);
+                }
+                return response.text();
+              })
+              .then(markdown => {
+                if (typeof marked === 'undefined') {
+                  console.error('marked.js is not loaded.');
+                  previewElement.textContent = "Error: Markdown parser not loaded.";
+                  return;
+                }
+                const html = marked.parse(markdown);
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = html;
+                const firstParagraph = tempDiv.querySelector('p');
+
+                if (firstParagraph) {
+                  let previewText = firstParagraph.textContent || firstParagraph.innerText || "";
+                  if (previewText.length > 200) {
+                    previewText = previewText.substring(0, 200).trim() + "...";
+                  }
+                  previewElement.textContent = previewText;
+                } else {
+                  previewElement.textContent = "No preview available.";
+                }
+              })
+              .catch(error => {
+                console.error('Error fetching or parsing markdown:', error);
+                previewElement.textContent = "Preview not found or error loading.";
+              });
+          } else {
+            // If postName is not found, it implies the link is not for a post or is malformed.
+            // previewElement.textContent = "Not a post link.";
+            // previewElement.style.display = 'none'; // Or hide it
+          }
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', loadPostPreviews);
+  </script>
 </body>
 </html>

--- a/operating_system.html
+++ b/operating_system.html
@@ -82,151 +82,181 @@
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">5G and eSIM</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">BitLocker</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">BitLocker To Go</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Certificates</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Code Signing and Integrity</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Config Refresh</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Controlled Folder Access</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Cryptography</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Device Health Attestation</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Domain Name System (DNS) Security</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Email Encryption</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Encrypted File System (EFS)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Encrypted Hard Drive</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Exploit Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Internet Protocol Security (IPSec)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Kiosk Mode</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Defender Antivirus</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Defender Application Guard</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Defender For Business</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Network Access Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Personal Data Encryption</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Rust For Windows</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Server Message Block (SMB) For Remote Connections</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Tamper Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Transport Layer Security (TLS)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Wi-Fi Protection</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Firewall</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Protected Process</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Security App</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Security Policy Settings And Auditing</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
@@ -234,5 +264,63 @@
     </main>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    function loadPostPreviews() {
+      const postContainers = document.querySelectorAll('.grid > div.bg-white');
+      postContainers.forEach(container => {
+        const postLink = container.querySelector('a[href*="post_template.html?post="]');
+        const previewElement = container.querySelector('.post-preview-text');
+
+        if (postLink && previewElement) {
+          const href = postLink.getAttribute('href');
+          const urlParams = new URLSearchParams(href.split('?')[1]);
+          const postName = urlParams.get('post');
+
+          if (postName) {
+            const markdownFilePath = `posts/md/${postName}.md`;
+            fetch(markdownFilePath)
+              .then(response => {
+                if (!response.ok) {
+                  throw new Error(`HTTP error! status: ${response.status} for ${markdownFilePath}`);
+                }
+                return response.text();
+              })
+              .then(markdown => {
+                if (typeof marked === 'undefined') {
+                  console.error('marked.js is not loaded.');
+                  previewElement.textContent = "Error: Markdown parser not loaded.";
+                  return;
+                }
+                const html = marked.parse(markdown);
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = html;
+                const firstParagraph = tempDiv.querySelector('p');
+
+                if (firstParagraph) {
+                  let previewText = firstParagraph.textContent || firstParagraph.innerText || "";
+                  if (previewText.length > 200) {
+                    previewText = previewText.substring(0, 200).trim() + "...";
+                  }
+                  previewElement.textContent = previewText;
+                } else {
+                  previewElement.textContent = "No preview available.";
+                }
+              })
+              .catch(error => {
+                console.error('Error fetching or parsing markdown:', error);
+                previewElement.textContent = "Preview not found or error loading.";
+              });
+          } else {
+            // If postName is not found, it implies the link is not for a post or is malformed.
+            // previewElement.textContent = "Not a post link.";
+            // previewElement.style.display = 'none'; // Or hide it
+          }
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', loadPostPreviews);
+  </script>
 </body>
 </html>

--- a/security_foundation.html
+++ b/security_foundation.html
@@ -82,46 +82,55 @@
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Common Criteria (CC)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">DevDivSecOps</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Federal Information Processing Standard (FIPS)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Microsoft Offensive Research And Security Engineering (MORSE)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Secure Future Initiative (SFI)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Security Development Lifecycle (SDL)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Software Bill Of Materials (SBOM)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Kernel And Microsoft Bug Bounty Programs</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out border border-gray-200 dark:border-gray-700">
           <h2 class="font-semibold text-xl text-blue-600 dark:text-blue-400 mb-2">Windows Software Development Kit (SDK)</h2>
+          <p class="post-preview-text text-gray-600 dark:text-gray-400 text-sm mt-1">Preview loading...</p>
           <a href="#!" class="text-orange-500 dark:text-orange-400 hover:underline font-medium text-sm">Read more... (Content Coming Soon)</a>
         </div>
 
@@ -129,5 +138,63 @@
     </main>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    function loadPostPreviews() {
+      const postContainers = document.querySelectorAll('.grid > div.bg-white');
+      postContainers.forEach(container => {
+        const postLink = container.querySelector('a[href*="post_template.html?post="]');
+        const previewElement = container.querySelector('.post-preview-text');
+
+        if (postLink && previewElement) {
+          const href = postLink.getAttribute('href');
+          const urlParams = new URLSearchParams(href.split('?')[1]);
+          const postName = urlParams.get('post');
+
+          if (postName) {
+            const markdownFilePath = `posts/md/${postName}.md`;
+            fetch(markdownFilePath)
+              .then(response => {
+                if (!response.ok) {
+                  throw new Error(`HTTP error! status: ${response.status} for ${markdownFilePath}`);
+                }
+                return response.text();
+              })
+              .then(markdown => {
+                if (typeof marked === 'undefined') {
+                  console.error('marked.js is not loaded.');
+                  previewElement.textContent = "Error: Markdown parser not loaded.";
+                  return;
+                }
+                const html = marked.parse(markdown);
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = html;
+                const firstParagraph = tempDiv.querySelector('p');
+
+                if (firstParagraph) {
+                  let previewText = firstParagraph.textContent || firstParagraph.innerText || "";
+                  if (previewText.length > 200) {
+                    previewText = previewText.substring(0, 200).trim() + "...";
+                  }
+                  previewElement.textContent = previewText;
+                } else {
+                  previewElement.textContent = "No preview available.";
+                }
+              })
+              .catch(error => {
+                console.error('Error fetching or parsing markdown:', error);
+                previewElement.textContent = "Preview not found or error loading.";
+              });
+          } else {
+            // If postName is not found, it implies the link is not for a post or is malformed.
+            // previewElement.textContent = "Not a post link.";
+            // previewElement.style.display = 'none'; // Or hide it
+          }
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', loadPostPreviews);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces dynamic post previews on category pages.

Key changes:
- Added JavaScript to category pages (`cloud_services.html`, `identity.html`, etc.) to fetch the content of linked Markdown posts.
- The script uses `marked.min.js` to parse the Markdown and extracts the first paragraph as a preview.
- Previews are displayed below the post title, truncated to 200 characters if longer.
- HTML placeholders for previews have been added to each post item on category pages.
- Error handling is in place for cases where posts are not found or content cannot be parsed, displaying a 'No preview available' message.
- The first post item in `cloud_services.html` was temporarily linked to `sample-markdown-post.md` to demonstrate the functionality. Other links remain as `#!`.

This enhancement improves your experience by providing a glimpse of the post content directly on category pages, helping you decide what to read.