### PR TITLE
feat: Add up arrow icon to floating action button

### DIFF
--- a/post_template.html
+++ b/post_template.html
@@ -239,6 +239,10 @@
       });
   });
 </script>
-<button id="jump-to-toc-btn" class="fixed bottom-5 right-5 bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full shadow-lg z-50"></button>
+<button id="jump-to-toc-btn" class="fixed bottom-5 right-5 bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full shadow-lg z-50">
+  <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 8">
+    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7 7 1 1 7"/>
+  </svg>
+</button>
 </body>
 </html>


### PR DESCRIPTION
Added an SVG up arrow icon to the floating action button (`jump-to-toc-btn`) on the post template page (`post_template.html`).

This change enhances the button's UI by providing a visual cue for its action, which is to scroll to the Table of Contents. The icon is styled using existing Tailwind CSS classes and inherits the button's color. The button's existing functionality remains unchanged.