### PR TITLE
feat: Add Google Analytics via dynamic script injection

### DIFF
--- a/application.html
+++ b/application.html
@@ -203,5 +203,6 @@
     document.addEventListener('DOMContentLoaded', loadPostPreviews);
   </script>
   <script src="js/ai-reminder.js" defer></script>
+  <script src="js/google-analytics.js" defer></script>
 </body>
 </html>

--- a/cloud_services.html
+++ b/cloud_services.html
@@ -257,5 +257,6 @@
     document.addEventListener('DOMContentLoaded', loadPostPreviews);
   </script>
   <script src="js/ai-reminder.js" defer></script>
+  <script src="js/google-analytics.js" defer></script>
 </body>
 </html>

--- a/hardware.html
+++ b/hardware.html
@@ -203,5 +203,6 @@
     document.addEventListener('DOMContentLoaded', loadPostPreviews);
   </script>
   <script src="js/ai-reminder.js" defer></script>
+  <script src="js/google-analytics.js" defer></script>
 </body>
 </html>

--- a/identity.html
+++ b/identity.html
@@ -257,5 +257,6 @@
     document.addEventListener('DOMContentLoaded', loadPostPreviews);
   </script>
   <script src="js/ai-reminder.js" defer></script>
+  <script src="js/google-analytics.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -123,5 +123,6 @@
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
   <script src="js/ai-reminder.js" defer></script>
+  <script src="js/google-analytics.js" defer></script>
 </body>
 </html>

--- a/js/google-analytics.js
+++ b/js/google-analytics.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', function() {
+  // Create the first script element
+  const script1 = document.createElement('script');
+  script1.async = true;
+  script1.src = 'https://www.googletagmanager.com/gtag/js?id=G-NZ3EC3JMH0';
+
+  // Create the second script element
+  const script2 = document.createElement('script');
+  script2.innerHTML = `
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-NZ3EC3JMH0');
+  `;
+
+  // Append both script elements to the document's <head>
+  document.head.appendChild(script1);
+  document.head.appendChild(script2);
+});

--- a/operating_system.html
+++ b/operating_system.html
@@ -323,5 +323,6 @@
     document.addEventListener('DOMContentLoaded', loadPostPreviews);
   </script>
   <script src="js/ai-reminder.js" defer></script>
+  <script src="js/google-analytics.js" defer></script>
 </body>
 </html>

--- a/post_template.html
+++ b/post_template.html
@@ -245,5 +245,6 @@
   </svg>
 </button>
 <script src="js/ai-reminder.js" defer></script>
+<script src="js/google-analytics.js" defer></script>
 </body>
 </html>

--- a/resources.html
+++ b/resources.html
@@ -105,5 +105,6 @@
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
   <script src="js/ai-reminder.js" defer></script>
+  <script src="js/google-analytics.js" defer></script>
 </body>
 </html>

--- a/security_foundation.html
+++ b/security_foundation.html
@@ -197,5 +197,6 @@
     document.addEventListener('DOMContentLoaded', loadPostPreviews);
   </script>
   <script src="js/ai-reminder.js" defer></script>
+  <script src="js/google-analytics.js" defer></script>
 </body>
 </html>

--- a/timeline.html
+++ b/timeline.html
@@ -71,5 +71,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
 <script src="timeline.js"></script>
   <script src="js/ai-reminder.js" defer></script>
+  <script src="js/google-analytics.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces Google Analytics tracking to the website.

A new JavaScript file, `js/google-analytics.js`, has been created. This script dynamically creates and injects the necessary Google Analytics gtag.js scripts into the `<head>` of the document when the DOM is loaded. This method ensures that the GA tags are added without needing to manually edit each HTML file's head section.

The `js/google-analytics.js` script is included with the `defer` attribute in the following HTML files, just before the closing `</body>` tag:
- index.html
- application.html
- cloud_services.html
- hardware.html
- identity.html
- operating_system.html
- post_template.html
- resources.html
- security_foundation.html
- timeline.html

This approach centralizes the Google Analytics configuration and makes it easier to manage and update in the future.